### PR TITLE
use Jakarta spec names in Profiles.adoc

### DIFF
--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -169,16 +169,16 @@ Optional)]”)
 * Support for _java:comp/ORB_ (see
 link:#a1385[See ORB References]”)
 
-=== [[a3252]]Full Java EE Product Requirements
+=== [[a3252]]Full Jakarta™ EE Product Requirements
 
 This section defines the requirements for
-full Java EE platform products. These requirements correspond to the
+full Jakarta EE platform products. These requirements correspond to the
 full set of requirements in previous versions of the Java EE platform
 specification and update those requirements for this new version of the
 platform.
 
 Please note that, due to the effects of the
-pruning process, future versions of the Java EE specification will
+pruning process, future versions of the Jakarta EE specification will
 likely relax the requirements given here, specifically by marking as
 optional technologies that have been subject to pruning and that are
 required by the present specification. The set of technologies that have
@@ -188,54 +188,50 @@ Technologies]”.
 
 The following technologies are required:
 
-* EJB 3.2 (except for EJB entity beans and
-associated EJB QL, which have been made optional)
-* Servlet 4.0
-* JSP 2.3
-* EL 3.0
-* JMS 2.0
-* JTA 1.2
-* JavaMail 1.6
-* Connector 1.7
-* Web Services 1.4
-* JAX-RS 2.1
-* WebSocket 1.1
-* JSON-P 1.1
-* JSON-B 1.0
-* Concurrency Utilities 1.0
-* Batch 1.0
-* Java EE Management 1.1
-* JACC 1.5
-* JASPIC 1.1
-* Java EE Security 1.0
-* JSP Debugging 1.0
-* JSTL 1.2
-* Web Services Metadata 2.1
-* JSF 2.3
-* Common Annotations 1.3
-* Java Persistence 2.2
-* Bean Validation 2.0
-* Managed Beans 1.0
-* Interceptors 1.2
-* Contexts and Dependency Injection for Java
-EE 2.0
-* Dependency Injection for Java 1.0
+* Jakarta Enterprise Beans 3.2 (except for Jakarta Enterprise Beans entity beans and
+associated Jakarta Enterprise Beans QL, which have been made optional)
+* Jakarta Servlet 4.0
+* Jakarta Server Pages 2.3
+* Jakarta Expression Language 3.0
+* Jakarta Messaging 2.0
+* Jakarta Transactions 1.2
+* Jakarta Mail 1.6
+* Jakarta Connectors 1.7
+* Jakarta XML Web Services 1.4
+* Jakarta RESTful Web Services 2.1
+* Jakarta WebSocket 1.1
+* Jakarta JSON Processing 1.1
+* Jakarta JSON Binding 1.0
+* Jakarta Concurrency 1.0
+* Jakarta Batch 1.0
+* Jakarta Management 1.1
+* Jakarta Authorization 1.5
+* Jakarta Authentication 1.1
+* Jakarta Security 1.0
+* Jakarta Debugging Support for Other Languages 1.0
+* Jakarta Standard Tag Library 1.2
+* Jakarta Web Services Metadata 2.1
+* Jakarta Server Faces 2.3
+* Jakarta Annotations 1.3
+* Jakarta Persistence 2.2
+* Jakarta Bean Validation 2.0
+* Jakarta Managed Beans 1.0
+* Jakarta Interceptors 1.2
+* Jakarta Contexts and Dependency Injection 2.0
+* Jakarta Dependency Injection 1.0
 
 
 
 The following technologies are optional:
 
-* EJB 3.2 and earlier entity beans and
-associated EJB QL
-* JAX-RPC 1.1
-* JAXR 1.0
-* Java EE Deployment 1.2
+* Jakarta Enterprise Beans 3.2 and earlier entity beans and associated Jakarta Enterprise Beans QL
+* Jakarta XML RPC 1.1
+* Jakarta XML Registries 1.0
+* Jakarta Deployment 1.2
 
 
 
-=== CHApter __ [[a3293]]
-
-[[a3294]]Application Clients
+=== [[a3294]]Application Clients
 
 This chapter describes application clients
 in the Java™ Platform, Enterprise Edition (Java EE).

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -194,7 +194,7 @@ associated Jakarta Enterprise Beans QL, which have been made optional)
 * Jakarta Server Pages 2.3
 * Jakarta Expression Language 3.0
 * Jakarta Messaging 2.0
-* Jakarta Transactions 1.2
+* Jakarta Transactions 1.3
 * Jakarta Mail 1.6
 * Jakarta Connectors 1.7
 * Jakarta XML Web Services 1.4


### PR DESCRIPTION
 use Jakarta spec names in the secion "Full Java EE Product Requirements" of "platform/Profiles.adoc".