### PR TITLE
Update TM syntax in asciidoc

### DIFF
--- a/specification/src/main/asciidoc/platform/CompatibilityMigration.adoc
+++ b/specification/src/main/asciidoc/platform/CompatibilityMigration.adoc
@@ -1,7 +1,7 @@
 == Compatibility and Migration
 
 This chapter summarizes compatibility and
-migration issues for the Jakarta&trade; EE platform. The specifications for each
+migration issues for the Jakarta(TM) EE platform. The specifications for each
 of the component technologies included in Jakarta EE also describe
 compatibility and migration issues for that technology in much more
 detail.


### PR DESCRIPTION
@smillidge, the %trade; syntax didn't render correctly for the TM reference in the Compatibility section.  I corrected this to just use (TM).  It looks like I dragged along some extra "empty" commits as I was getting my fork up-to-date, but you'll see that the only code change was to the Trademark reference.  Thanks.