### PR TITLE
Cleaning up WebProfile spec, license, and version

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-spec</artifactId>
     <packaging>pom</packaging>
-    <version>8.0-SNAPSHOT</version>
+    <version>8.0</version>
     <name>Jakarta EE Platform Specification</name>
 
     <properties>
@@ -41,7 +41,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <managedbean.version>1.0-SNAPSHOT</managedbean.version>  <!-- override <version> for Managed Beans spec-->
+        <managedbean.version>1.0</managedbean.version>  <!-- override <version> for Managed Beans spec-->
     </properties>
 
     <scm>

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -4,7 +4,12 @@ Specification: {doctitle}
 
 Version: {revnumber}
 
+ifeval::["{revremark}" != ""]
 Status: {revremark}
+endif::[]
+ifeval::["{revremark}" == ""]
+Status: Final Release
+endif::[]
 
 Release: {revdate}
 ....

--- a/specification/src/main/asciidoc/webprofile/Introduction.adoc
+++ b/specification/src/main/asciidoc/webprofile/Introduction.adoc
@@ -1,6 +1,6 @@
 == Introduction
 
-This specification defines the Jakarta EE Web
+This specification defines the Jakarta(TM) EE Web
 Profile (“Web Profile”), a profile of the Jakarta™ Platform, Enterprise
 Edition specifically targeted at web applications.
 
@@ -68,7 +68,11 @@ core (“à la carte” installation).
 
 === Determining Applicable Requirements
 
-*
+NOTE: Profile definitions can be quite terse, amounting to little more than a list of required technologies and a (possibly empty) set of additional requirements, beyond those entailed by all the referenced specifications.
+Being the first profile of the Java(TM) EE 6 Platform to be defined, we expect the Web Profile specification to be used as a model for future profiles.
+It will also be seen as a starting point for understanding how the requirements defined in the Jakarta EE Platform specification apply to a profile that subsets the platform itself, a significant innovation in this version of the platform.
+(The case of a profile that is a superset of the platform is much easier to picture.)
+To help with this process, this section attempts to shed light on how one should go from the definition of the Web Profile to figuring out Jakarta EE 8 Web Profile, the exact set of requirements that apply to it, and consequently to any product that implements it.
 
 As dictated by the general rules for Jakarta EE
 profiles in the Platform specification, products that implement the Web
@@ -86,10 +90,10 @@ technology or combinations of technologies.
 Let’s look at some examples of requirements
 from each grouping.
 
-For the first one, the Java EE Platform
+For the first one, the Jakarta EE Platform
 specification mandates support for the “ _java:_ ” naming context in all
 profiles. Consequently, Web Profile products must support it. For a
-similar reason, all Web Profile 8 products must support the Java Platform, Standard Edition 8 API.
+similar reason, all Web Profile 8 products must support the Java(TM) Platform, Standard Edition 8 API.
 
 In the second category one can point out the
 requirement to support Jakarta EE web application modules ( _.war_ files)
@@ -98,7 +102,7 @@ requirement to support Jakarta EE web application modules ( _.war_ files)
 The third category is hopefully
 self-explanatory. For example, Web Profile products must implement the
 Servlet API, which in turn means they need to satisfy all the
-requirements listed in the Servlet specification.
+requirements listed in the Jakarta Servlet specification.
 
 The fourth category is the most complex. As a
 first example, since a Web Profile product is required to implement the
@@ -109,8 +113,8 @@ pertain to Jakarta EE web containers, all interoperability requirements for
 such containers, etc. Furthermore, since a Web Profile product must
 implement the Jakarta Transactions API, it must also satisfy all the
 Platform specification’s transaction management-related requirements for
-web components, which indeed are conditional on the presence of Servlet
-and JTA .
+web components, which indeed are conditional on the presence of Jakarta Servlet
+and Jakarta Transactions.
 
 As a negative example for the fourth category
 of requirements, consider the Jakarta Messaging technology.
@@ -131,7 +135,7 @@ classes, component types and Jakarta Enterprise Beans container services are men
 requirement itself. Only if all of them fall inside the Jakarta Enterprise Beans Lite subset
 that requirement is considered applicable to Web Profile products.
 
-For example, since EJB Lite does not include
+For example, since Jakarta Enterprise Beans Lite does not include
 any remote functionality, the _EJB_ annotation may not be used to inject
 a remote reference, something that should be kept in mind when
 evaluating the requirements in the Platform specification section

--- a/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
@@ -1,51 +1,52 @@
+[appendix]
 == Related Documents
 
 This specification refers to the following
 documents. The terms used to refer to the documents in this
 specification are included in parentheses.
 
-_Jakarta™ EE Platform Specification Version 8. Available at: https://jakarta.ee/specifications/full-platform/8.0.1_
+_Jakarta™ EE Platform Specification Version 8. Available at: https://jakarta.ee/specifications/platform/8.0_
 
 _Java™ Platform, Standard Edition, v8 API Specification (Java SE specification). Available at: http://docs.oracle.com/javase/8/docs/_
 
-_Jakarta™ Enterprise Beans Specification, Version 3.2. Available at: https://jakarta.ee/specifications/enterprise-beans/2.3.2_
+_Jakarta™ Enterprise Beans Specification, Version 3.2. Available at: https://jakarta.ee/specifications/enterprise-beans/2.3_
 
-_Jakarta™ Server Pages Specification, Version 2.3. Available at: https://jakarta.ee/specifications/pages/2.3.4_
+_Jakarta™ Server Pages Specification, Version 2.3. Available at: https://jakarta.ee/specifications/pages/2.3_
 
-_Jakarta™ Expression Language Specification, Version 3.0. Available at: https://jakarta.ee/specifications/expression-language/3.0.2_
+_Jakarta™ Expression Language Specification, Version 3.0. Available at: https://jakarta.ee/specifications/expression-language/3.0_
 
-_Jakarta™ Servlet Specification, Version 4.0. Available at: https://jakarta.ee/specifications/servlet/4.0.2_
+_Jakarta™ Servlet Specification, Version 4.0. Available at: https://jakarta.ee/specifications/servlet/4.0_
 
-_Jakarta™ Transaction Specification, Version 1.2. Available at: https://jakarta.ee/specifications/transactions/1.3.2_
+_Jakarta™ Transaction Specification, Version 1.2. Available at: https://jakarta.ee/specifications/transactions/1.3_
 
-_Jakarta™ RESTful Web Services Specification, Version 2.1. Available at: https://jakarta.ee/specifications/restful-ws/2.1.5_
+_Jakarta™ RESTful Web Services Specification, Version 2.1. Available at: https://jakarta.ee/specifications/restful-ws/2.1_
 
-_Jakarta™ Annotations Specification, Version 1.3. Available at: https://jakarta.ee/specifications/annotations/1.3.4_
+_Jakarta™ Annotations Specification, Version 1.3. Available at: https://jakarta.ee/specifications/annotations/1.3_
 
 _Jakarta™ Debugging Support for Other Languages Specification, Version 1.0. Available at: https://jakarta.ee/specifications/debugging/1.0_
 
-_Jakarta™ Standard Tag Library Specification, Version 1.2. Available at: https://jakarta.ee/specifications/tags/1.2.3_
+_Jakarta™ Standard Tag Library Specification, Version 1.2. Available at: https://jakarta.ee/specifications/1.2_
 
-_Jakarta™ Server Faces Specification, Version 2.3. Available at: https://jakarta.ee/specifications/faces/2.3.1_
+_Jakarta™ Server Faces Specification, Version 2.3. Available at: https://jakarta.ee/specifications/faces/2.3_
 
-_Jakarta™ Persistence Specification, Version 2.2. Available at: https://jakarta.ee/specifications/persistence/2.2.2_
+_Jakarta™ Persistence Specification, Version 2.2. Available at: https://jakarta.ee/specifications/persistence/2.2_
 
 _Jakarta™ Bean Validation Specification, Version 2.0. Available at: https://jakarta.ee/specifications/bean-validation/2.0_
 
-_Jakarta™ Managed Beans Specification, Version 1.0. Available at: https://jakarta.ee/specifications/managed-beans/1.0.0_
+_Jakarta™ Managed Beans Specification, Version 1.0. Available at: https://jakarta.ee/specifications/managed-beans/1.0_
 
-_Jakarta™ Interceptors Specification, Version 1.2. Available at: https://jakarta.ee/specifications/interceptors/1.2.3_
+_Jakarta™ Interceptors Specification, Version 1.2. Available at: https://jakarta.ee/specifications/interceptors/1.2_
 
 _Jakarta™ Contexts and Dependency Injection Specification, Version 2.0. Available at: https://jakarta.ee/specifications/cdi/2.0_
 
 _Jakarta™ Dependency Injection Specification, Version 1.0. Available at: https://jakarta.ee/specifications/dependency-injection/1.0_
 
-_Jakarta™ WebSocket Specification, Version 1.1. Available at: https://jakarta.ee/specifications/websocket/1.1.1_
+_Jakarta™ WebSocket Specification, Version 1.1. Available at: https://jakarta.ee/specifications/websocket/1.1_
 
-_Jakarta™ JSON Processing Specification, Version 1.1. Available at: https://jakarta.ee/specifications/jsonp/1.1.5_
+_Jakarta™ JSON Processing Specification, Version 1.1. Available at: https://jakarta.ee/specifications/jsonp/1.1_
 
-_Jakarta™ JSON Binding Specification, Version 1.0. Available at: https://jakarta.ee/specifications/jsonb/1.0.1_
+_Jakarta™ JSON Binding Specification, Version 1.0. Available at: https://jakarta.ee/specifications/jsonb/1.0_
 
-_Jakarta™ Security Specification, Version 1.0. Available at: https://jakarta.ee/specifications/security/1.0.1_
+_Jakarta™ Security Specification, Version 1.0. Available at: https://jakarta.ee/specifications/security/1.0_
 
-_Jakarta™ Authentication Specification, Version 1.1. Available at: https://jakarta.ee/specifications/authentication/1.1.2_
+_Jakarta™ Authentication Specification, Version 1.1. Available at: https://jakarta.ee/specifications/authentication/1.1_

--- a/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
@@ -1,8 +1,9 @@
+[appendix]
 == Revision History
 
 === Changes in Early Draft
 
-=== Additional Requirements
+==== Additional Requirements
 
 * Java EE 8 Web Profile requires Java SE 8.
 * Updated to reflect versions of Java EE 8
@@ -10,42 +11,42 @@ technologies.
 * Added JSON-B as required component.
 * Added MVC as required component.
 
-=== Removed Requirements
+==== Removed Requirements
 
-=== None
+* None
 
-=== Editorial Changes
+==== Editorial Changes
 
 * Updated Related Documents.
 
 === Changes in Early Draft 2
 
-=== Additional Requirements
+==== Additional Requirements
 
 * None
 
-=== Removed Requirements
+==== Removed Requirements
 
 * Removed MVC 1.0 from
 <<a43, Required Components>>.
 
-=== Editorial Changes
+==== Editorial Changes
 
 * Changed version of Bean Validation from 1.1
 to 2.0.
 
 === Changes in Public Review Draft
 
-=== Additional Requirements
+==== Additional Requirements
 
 * Added Java EE Security API 1.0 and JASPIC 1.1
 as required components.
 
-=== Removed Requirements
+==== Removed Requirements
 
 * None
 
-=== Editorial Changes
+==== Editorial Changes
 
 * Corrected version of WebSocket to 1.1.
 * Added acknowledgements.
@@ -53,9 +54,8 @@ as required components.
 
 === Changes in Proposed Final Draft
 
-=== Editorial Changes
+==== Editorial Changes
 
 * Added reference to
-_https:javaee.github.io/javaee-spec[]http:javaee.github.io/javaee-spec[]https:javaee.github.io/javaee-spec
-project._
+_https:javaee.github.io/javaee-spec_ project.
 * Updated “Related Documents.”

--- a/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
+++ b/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
@@ -39,7 +39,7 @@ Profile.
 
 Web Profile products may support some of the
 technologies present in the full Jakarta EE Platform and not already listed
-in <<a43, Required Components>>, 
+in <<a43, Required Components>>,
 consistently with their compatibility requirements.
 
 [[a69]]


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The original contribution somehow missed a whole [NOTE] section in the Introduction of the WebProfile specification.  There were also formatting issues with the Web Profile spec.  Missed references to "Java EE" and other acronyms.  I also setup the version numbers for the "final" release and did the efsl.adoc update asked for by Bill (although this may change again....).