### PR TITLE
Update and enforce min maven version

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -11,7 +11,7 @@ Building
 Prerequisites:
 
 * JDK8+
-* Maven 3.0.3+
+* Maven 3.0.5+
 
 Run the full build:
 

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -76,6 +76,10 @@
                                     <version>[1.8.0,)</version>
                                     <message>You need JDK8 or later</message>
                                 </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                    <message>You need Maven 3.0.5 or later</message>
+                                </requireMavenVersion>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
I took liberty to convert prerequisite from readme to enforcer rule, like it's done for JDK.