### PR TITLE
added some comments to explain a line separator

### DIFF
--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -127,4 +127,5 @@ Java™ Community Process
 _SM_ 2: Process Document, Version 2.10 (March 21, 2016). Available at
 _https://jcp.org/en/procedures/jcp2_ .
 
+// generates a line between text and footnotes for pdf and html generation.
 '''

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -1015,4 +1015,5 @@ the appropriate solution. We had to abandon this work for J2EE 1.3, and
 were not able to address it for J2EE 1.4, but hope to pursue it further
 in a future release.
 
+// generates a line between text and footnotes for pdf and html generation.
 '''

--- a/specification/src/main/asciidoc/platform/TransactionManagement.adoc
+++ b/specification/src/main/asciidoc/platform/TransactionManagement.adoc
@@ -447,4 +447,5 @@ allow the System Administrator to perform the following tasks:
 * Receive notifications of abnormal transaction processing conditions (such as
 abnormally high number of transaction rollbacks).
 
+// generates a line between text and footnotes for pdf and html generation.
 '''


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Adding a comment to the files that have footnotes generated to explain the extra line separator at the end of the file.  This should help with the accidental deletion of this line separator.