### PR TITLE
[WIP] Mapping of Java EE 8 and Jakarta EE 8 brands and versions

### DIFF
--- a/specification/src/main/asciidoc/platform/BrandMapping.adoc
+++ b/specification/src/main/asciidoc/platform/BrandMapping.adoc
@@ -1,0 +1,114 @@
+[cols=2, options=header]
+.Java EE to Jakarta EE Mapping
+|===
+|Java EE Technology
+|Jakarta EE Technology
+
+|Java™ Platform, Enterprise Edition 8
+|Jakarta™ EE Platform 8
+
+|Enterprise JavaBeans™ 3.2
+|Jakarta™ Enterprise Beans 3.2
+
+|JavaServer Pages™ 2.3
+|Jakarta™ Server Pages 2.3
+
+|Expression Language 3.0
+|Jakarta™ Expression Language 3.0
+
+|Common Annotations for the Java Platform 1.3
+|Jakarta™ Annotations 1.3
+
+|Java™ Servlet 4.0
+|Jakarta™ Servlet 4.0
+
+|Java™ Message Service 2.0
+|Jakarta™ Messaging 2.0
+
+|Java™ Transaction API 1.2
+|Jakarta™ Transaction 1.3
+
+|JavaMail™ API 1.6
+|Jakarta™ Mail 1.6
+
+|JavaBeans™ Activation Framework 1.1
+|Jakarta™ Activation 1.2
+
+|Java EE™ Connector Architecture 1.7
+|Jakarta™ Connectors 1.7
+
+|Web Services for Java EE 1.4
+|Jakarta™ XML Web Services 2.3
+
+|Java™ API for XML-based RPC 1.1
+|Jakarta™ XML RPC 1.1
+
+|SOAP with Attachments API for Java™ 1.3
+|Jakarta™ SOAP with Attachments 1.4
+
+|Java™ API for XML Registries 1.0
+|Jakarta™ XML Registries 1.0
+
+|Java™ API for RESTful Web Services 2.1
+|Jakarta™ RESTful Web Services 2.1
+
+|Java™ Platform, Enterprise Edition Management 1.1
+|Jakarta™ Management 1.1
+
+|Java™ Platform, Enterprise Edition Deployment 1.2
+|Jakarta™ Deployment 1.7
+
+|Java™ Authorization Service Provider Contract for Containers 1.5
+|Jakarta™ Authorization 1.5
+
+|Java™ Authentication Service Provider Interface for Containers 1.1
+|Jakarta™ Authentication 1.1
+
+|Java™ EE Security API 1.0
+|Jakarta™ Security 1.0
+
+|Debugging Support for Other Languages 1.0
+|Jakarta™ Debugging Support for Other Languages 1.0
+
+|Standard Tag Library for JavaServer Pages 1.2
+|Jakarta™ Standard Tag Library 1.2
+
+|Web Services Metadata for the Java Platform 2.1
+|Jakarta™ Web Services Metadata 1.1
+
+|JavaServer Faces 2.3
+|Jakarta™ Server Faces 2.3
+
+|Java Persistence 2.2
+|Jakarta™ Persistence 2.2
+
+|Bean Validation 2.0
+|Jakarta™ Bean Validation 2.0
+
+|Managed Beans 1.0
+|Jakarta™ Managed Beans 1.0
+
+|Interceptors 1.2 rev A
+|Jakarta™ Interceptors 1.2
+
+|Contexts and Dependency Injection for the Java EE Platform 2.0
+|Jakarta™ Contexts and Dependency Injection 2.0
+
+|Dependency Injection for Java 1.0
+|Jakarta™ Dependency Injection 1.0
+
+|Java API for WebSocket 1.1
+|Jakarta™ WebSocket 1.1
+
+|Java API for JSON Processing 1.1
+|Jakarta™ JSON Processing 1.1
+
+|Java API for JSON Binding 1.0
+|Jakarta™ JSON Binding 1.0
+
+|Concurrency Utilities for Java EE 1.0
+|Jakarta™ Concurrency 1.1
+
+|Batch Applications for the Java Platform 1.0 rev A
+|Jakarta™ Batch 1.0
+|===


### PR DESCRIPTION
This is a work-in-progress (WIP) PR to create a mapping between Java EE 8 and Jakarta EE 8 for inclusion somewhere in the Jakarta EE 8 specification.

Current thinking on how to complete this PR involves potentially a new Appendix, potentially positioned before "Appendix C: Related Documents."  The new appendix can be mentioned via link in "2.20. Changes in Jakarta EE 8."

Providing an early draft PR so if there are thoughts or preferences, they can be incorporated asap.