### PR TITLE
Versions and pruning

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -1618,18 +1618,6 @@ Resource Adapters.
 The Jakarta EE Connectors specification is available at
 _https://jakarta.ee/specifications/connectors_ .
 
-=== Jakarta EE XML Web Services 2.3 Requirements
-
-The Jakarta EE XML Web Services specification
-defines the capabilities a Jakarta EE application server must support for
-deployment of web service endpoints. A complete deployment model is
-defined, including several new deployment descriptors. All Jakarta EE
-products must support the deployment and execution of web services as
-specified by the Web Services for Jakarta EE specification.
-
-The Jakarta EE XML Web Services specification is
-available at _https://jakarta.ee/specifications/xml-ws_ .
-
 === Jakarta XML RPC 1.1 Requirements (Optional)
 
 The Jakarta XML RPC specification defines client APIs
@@ -1862,17 +1850,6 @@ to provide a Jakarta Standard Tag Library for use by all Jakarta Server Pages.
 
 The Jakarta Standard Tag Library for Jakarta Server Pages
 specification can be found at _https://jakarta.ee/specifications/tags_ .
-
-=== Jakarta Web Services Metadata Platform 1.1 Requirements
-
-The Jakarta Web Services Metadata
-Platform specification defines Java language annotations that can be
-used to simplify the development of web services. These annotations can
-be used with Jakarta XML Web Services components.
-
-The Jakarta Web Services Metadata
-Platform specification can be found at
-_https://jakarta.ee/specifications/ws-metadata_ .
 
 === Jakarta Server Faces 2.3 Requirements
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -112,7 +112,7 @@ POPT footnote:[IIOP interoperability, including Jakarta(TM) Enterprise Beans 2.x
 |N
 |REQ
 
-|EL 3.0
+|Expression Language 3.0
 |N
 |Y
 |N
@@ -124,13 +124,13 @@ POPT footnote:[IIOP interoperability, including Jakarta(TM) Enterprise Beans 2.x
 |Y
 |REQ
 
-|Transactions 1.2
+|Transactions 1.3
 |N
 |Y
 |Y
 |REQ
 
-|JavaMail 1.6
+|Mail 1.6
 |Y
 |Y
 |Y
@@ -142,7 +142,7 @@ POPT footnote:[IIOP interoperability, including Jakarta(TM) Enterprise Beans 2.x
 |Y
 |REQ
 
-|Web Services 1.4
+|Enterprise Web Services 1.4
 |Y
 |Y
 |Y
@@ -166,19 +166,19 @@ POPT footnote:[IIOP interoperability, including Jakarta(TM) Enterprise Beans 2.x
 |N
 |REQ
 
-|JSON-P 1.1
+|JSON Processing 1.1
 |Y
 |Y
 |Y
 |REQ
 
-|JSON-B 1.0
+|JSON Binding 1.0
 |Y
 |Y
 |Y
 |REQ
 
-|Concurrency Utilities 1.0
+|Concurrency 1.1
 |N
 |Y
 |Y
@@ -202,8 +202,8 @@ POPT footnote:[IIOP interoperability, including Jakarta(TM) Enterprise Beans 2.x
 |Y
 |REQ
 
-|Deployment 1.2 footnote:[See
-<<a2730, Jakarta™ Enterprise Edition Deployment API 1.2 Requirements (Optional)>> for
+|Deployment 1.7 footnote:[See
+<<a2730, Jakarta™ Enterprise Edition Deployment API 1.7 Requirements (Optional)>> for
 details.]
 |N
 |N
@@ -240,7 +240,7 @@ details.]
 |N
 |REQ
 
-|Web Services Metadata 2.1
+|Web Services Metadata 1.1
 |Y
 |Y
 |Y
@@ -282,8 +282,7 @@ details.]
 |Y
 |REQ
 
-|Contexts and Dependency Injection
-2.0
+|Contexts and Dependency Injection 2.0
 |Y
 |Y
 |Y

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -240,12 +240,6 @@ details.]
 |N
 |REQ
 
-|Web Services Metadata 1.1
-|Y
-|Y
-|Y
-|REQ
-
 |Server Faces 2.3
 |N
 |Y
@@ -336,6 +330,12 @@ The following specifications are outside Jakarta EE, provided by the Java™ run
 |REQ
 
 |XML Binding 2.3
+|Y
+|Y
+|Y
+|REQ
+
+|Web Services Metadata 1.1
 |Y
 |Y
 |Y

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -310,6 +310,46 @@ an exception to this in order to accommodate interface type dependencies—for e
 the Jakarta™ Enterprise Beans SessionContext dependency on the
 _javax.xml.rpc.handler.MessageContext_ type.]
 
+The following specifications are outside Jakarta EE, provided by the Java™ runtime.
+
+[[a2159]]
+[cols=5, options=header]
+.Jakarta EE Technologies
+|===
+|Java Technology
+|App Client
+|Web
+|Enterprise Beans
+|Status
+
+
+|Activation 1.2
+|Y
+|Y
+|Y
+|REQ
+
+|SOAP with Attachments 1.4
+|Y
+|Y
+|Y
+|REQ
+
+|XML Binding 2.3
+|Y
+|Y
+|Y
+|REQ
+
+|XML Web Services 2.3
+|Y
+|Y
+|Y
+|REQ
+
+|===
+
+
 [[a2331]]
 ==== Pruned Java Technologies
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -1500,7 +1500,7 @@ enterprise beans container and the web container.
 The Jakarta Messaging specification is available at
 _ https://jakarta.ee/specifications/messaging_ .
 
-=== Jakarta Transaction 1.2 Requirements
+=== Jakarta Transaction 1.3 Requirements
 
 Jakarta Transaction defines the _UserTransaction_ interface
 that is used by applications to start, and commit or abort transactions.
@@ -1618,7 +1618,7 @@ Resource Adapters.
 The Jakarta EE Connectors specification is available at
 _https://jakarta.ee/specifications/connectors_ .
 
-=== Jakarta EE XML Web Services Requirements
+=== Jakarta EE XML Web Services 2.3 Requirements
 
 The Jakarta EE XML Web Services specification
 defines the capabilities a Jakarta EE application server must support for
@@ -1720,7 +1720,7 @@ required to support the JSON-B API.
 The Jakarta JSON Binding  specification
 can be found at _https://jakarta.ee/specifications/jsonb_.
 
-=== Jakarta Concurrency 1.0 (Concurrency Utilities) Requirements
+=== Jakarta Concurrency 1.1 (Concurrency Utilities) Requirements
 
 Jakarta Concurrency Utilities for Jakarta EE is a
 standard API for providing asynchronous capabilities to Jakarta EE
@@ -1737,7 +1737,7 @@ required to be supported.
 The Jakarta Concurrency
 specification can be found at _https://jakarta.ee/specifications/concurrency_ .
 
-=== Jakarta Batch Specification Requirements
+=== Jakarta Batch 1.0 Specification Requirements
 
 The Jakarta Batch provides a programming model for batch
 applications and a runtime for scheduling and executing jobs.
@@ -1770,7 +1770,7 @@ The Jakarta Management specification is
 available at _https://jakarta.ee/specifications/management_ .
 
 [[a2730]]
-=== Jakarta Deployment API 1.2 Requirements (Optional)
+=== Jakarta Deployment API 1.7 Requirements (Optional)
 
 The Jakarta Deployment API defines the
 interfaces between the runtime environment of a deployment tool and
@@ -1841,7 +1841,7 @@ requirements defined by the Jakarta Security specification.
 The Jakarta Security Specification can be
 found at _https://jakarta.ee/specifications/security_ .
 
-=== Jakarta Debugging Support for Other Languages Requirements
+=== Jakarta Debugging Support for Other Languages Requirements 1.0
 
 Jakarta Server Pages pages are usually translated into Java
 language pages and then compiled to create class files. The Jakarta Debugging Support for Other Languages
@@ -1863,7 +1863,7 @@ to provide a Jakarta Standard Tag Library for use by all Jakarta Server Pages.
 The Jakarta Standard Tag Library for Jakarta Server Pages
 specification can be found at _https://jakarta.ee/specifications/tags_ .
 
-=== Jakarta Web Services Metadata Platform 2.1 Requirements
+=== Jakarta Web Services Metadata Platform 1.1 Requirements
 
 The Jakarta Web Services Metadata
 Platform specification defines Java language annotations that can be

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -2063,5 +2063,12 @@ Injection>>” for more detail.
 The DI specification can be found at
 _https://jakarta.ee/specifications/dependency-injection_ .
 
+=== Enterprise Web Services 1.4 Requirements
+
+The Enterprise Web Services specification defines the integration between the various Web Service technologies in Jakarta EE, including XML-RPC, XMl Web Services and XML Web Service Metadata.
+
+The Enterprise Web Services specification can be found
+at _https://jakarta.ee/specifications/enterprise-ws_ .
+
 // generates a line between text and footnotes for pdf and html generation.
 '''

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -306,9 +306,9 @@ _javax.xml.rpc.handler.MessageContext_ type.]
 
 The following specifications are outside Jakarta EE, provided by the Java™ runtime.
 
-[[a2159]]
+[[a21591]]
 [cols=5, options=header]
-.Jakarta EE Technologies
+.Java Technologies outside Jakarta EE
 |===
 |Java Technology
 |App Client


### PR DESCRIPTION
This PR is intentionally a branch in the `eclipse-ee4j/jakartaee-platform` repository so that anyone can commit updates.

The most difficult aspect of this PR is making a judgement call on how to handle our inconsistent treatment of what we've come to consider inside Jakarta EE vs outside Jakarta EE.

In the `Required Java Technologies` section, XML Web Services Metadata was mentioned, but has been deemed outside Jakarta EE.  For this section I opted to create an explicit "outside" Jakarta EE table so there was explicit documentation in the specification of our thinking.

Where there were explicit sections dedicated to Specifications, these changes were made:

 - Added `Enterprise Web Services 1.4 Requirements`
 - Removed `XML Web Services 2.3 Requirements`
 - Removed `XML Web Services Metadata 1.4 Requirements`

It was very tempting to instead add sections for:

 - Activation  1.2
 - SOAP with Attachments 1.4
 - XML Binding 2.3

When I realized the URL for XML Web Services 2.3 in the spec was listed as `https://jakarta.ee/specifications/xml-ws`, but the PR was using `https://jakarta.ee/specifications/xml-web-services` I decided against adding them as before an approved PR, there is still room for mistakes.

Careful review is needed for the new table `Java Technologies outside Jakarta EE`, specifically the "Y" and "N" booleans are likely not correct.  I defaulted to "Y" as they are theoretically part of the JVM and expected to be there even if not explicitly leveraged.

Given the timeline, the proper handling of this PR is not to propose changes, but to make them.  Commit away.