### PR TITLE
Jakarta EE 8 Branch (post release)

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-spec</artifactId>
     <packaging>pom</packaging>
-    <version>8</version>
+    <version>9-SNAPSHOT</version>
     <name>Jakarta EE Platform Specification</name>
 
     <properties>
@@ -41,7 +41,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <managedbean.version>1.0</managedbean.version>  <!-- override <version> for Managed Beans spec-->
+        <managedbean.version>1.1-SNAPSHOT</managedbean.version>  <!-- override <version> for Managed Beans spec-->
     </properties>
 
     <scm>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

I know this is manual, but the Jenkins jobs are not available for this.  Also, the inclusion of Managed Beans 1.0 in the same repo complicates things.  We need to clean this up post Jakarta EE 8.  I'll open a separate Issue.  In the mean time, these changes will prep for the builds once we complete Jakarta EE 8.