### PR TITLE
Correct links. No content is changed except the link to JAXB document…

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -62,7 +62,7 @@ Jakarta Connector specifications include the XML Schema definition of the
 associated module level deployment descriptors and component packaging
 architecture required to produce Jakarta EE modules. (The application
 client specification is found in
-<<a3293, CHApter>> of this
+<<a3294, Application Clients chapter>> of this
 document.)
 
 A Jakarta EE module is a collection of one or more

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -781,7 +781,7 @@ set declaration:
 
 
 The Jakarta EE permissions XML Schema is located
-at _http://xmlns.jcp.org/xml/ns/javaee/permissions_8.xsd_ .
+at _http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd_ .
 
 ==== Additional Requirements
 
@@ -1451,7 +1451,7 @@ general, the behavior of a Jakarta Messaging provider should be the same in both
 enterprise beans container and the web container.
 
 The Jakarta Messaging specification is available at
-_ https://jakarta.ee/specifications/messaging_ .
+_https://jakarta.ee/specifications/messaging_ .
 
 === Jakarta Transaction 1.3 Requirements
 
@@ -1958,7 +1958,7 @@ resource injection facility and interceptor service present in the Jakarta
 EE platform.
 
 The Managed Beans specification can be found
-at _https://jakarta.ee/specifications/managed-beans_ .
+at _https://jakarta.ee/specifications/managedbeans_ .
 
 === Interceptors 1.2 Requirements
 

--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -6,7 +6,7 @@ This specification refers to the following
 documents. The terms used to refer to the documents in this
 specification are included in parentheses.
 
-_Jakarta™ EE Platform Specification Version 8_. Available at: _https://jakarta.ee/specifications/full-platform/8.0_
+_Jakarta™ EE Platform Specification Version 8_. Available at: _https://jakarta.ee/specifications/full-platform/8_
 
 _Java™ Platform, Standard Edition, v8 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/javase/8/docs/_
 
@@ -36,7 +36,7 @@ _JavaBeans™ Activation Framework Specification Version 1.2 (JAF specification)
 
 _Jakarta™ Connectors Specification, Version 1.7_. Available at: _https://jakarta.ee/specifications/connectors/1.7_
 
-_Jakarta™ XML Web Services Specification, Version 2.3_. Available at: _https://jakarta.ee/specifications/xml-web-services/2.3_
+_Jakarta™ XML Web Services Specification, Version 2.3_. Available soon from: _https://jakarta.ee/specifications/xml-web-services/2.3_
 
 _Jakarta™ XML RPC Specification, Version 1.1_. Available at: _https://jakarta.ee/specifications/xml-rpc/1.1_
 
@@ -44,7 +44,7 @@ _SOAP with Attachments API for Java™ 1.4 (SAAJ specification)_. Available at: 
 
 _Jakarta™ XML Registries Specification, Version 1.0_. Available at: _https://jakarta.ee/specifications/xml-registries/1.0_
 
-_Jakarta™ RESTful Web Services Specification, Version 2.1_. Available at: _https://jakarta.ee/specifications/restful-web-services/2.1_
+_Jakarta™ RESTful Web Services Specification, Version 2.1_. Available at: _https://jakarta.ee/specifications/restful-ws/2.1_
 
 _Jakarta™ Management Specification, Version 1.1_. Available at: _https://jakarta.ee/specifications/management/1.1_
 
@@ -68,7 +68,7 @@ _Jakarta™ Persistence Specification, Version 2.2_. Available at: _https://jaka
 
 _Jakarta™ Bean Validation Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/bean-validation/2.0_
 
-_Jakarta™ Managed Beans Specification, Version 1.0_. Available at: _https://jakarta.ee/specifications/managed-beans/1.0_
+_Jakarta™ Managed Beans Specification, Version 1.0_. Available at: _https://jakarta.ee/specifications/managedbeans/1.0_
 
 _Jakarta™ Interceptors Specification, Version 1.2_. Available at: _https://jakarta.ee/specifications/interceptors/1.2_
 
@@ -122,7 +122,7 @@ _https://tools.ietf.org/html/rfc6101_ .
 Architectural Styles and the Design of
 Network-based Software Architectures (REST), R. Fielding, Ph.d
 dissertation, University of California, Irvine, 2000. Available at
-_https://roy.gbiv.com/pubs/dissertation/top.html_ .
+_https://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm_ .
 
 Java™ Community Process
 _SM_ 2: Process Document, Version 2.10 (March 21, 2016). Available at

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -801,7 +801,7 @@ define the relationship between the operating system identity associated
 with a running application client and the authenticated user identity,
 support for single signon requires that the Jakarta EE product be able to
 relate these identities. Additional application client requirements are
-described in <<a3293, CHApter>>
+described in <<a3294, Application Clients chapter>>
 of this specification.
 
 ==== Resource Authentication Requirements


### PR DESCRIPTION
… has a parenthetical that it doesn't currently work since that spec. has not yet been ratified.
(This will replace previous PR 117, which did not have proper "sign-off."

Signed-off-by: Ed Bratt <ed.bratt@oracle.com>