### PR TITLE
Update Previous DD section per Jakarta EE 9 release plan and ...

### DIFF
--- a/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
+++ b/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
@@ -3,17 +3,32 @@
 == Previous Version Deployment Descriptors
 
 This appendix describes Document Type
-Definitions and XML schemas for Deployment Descriptors from previous
-versions of the Java EE specification. All Jakarta EE products are required
-to support these DTDs and schemas as well as the schemas specified in
-this version of the specification. This ensures that applications
-written to previous versions of this specification can be deployed on
-products supporting the current version of this specification. In
-addition, there are no restrictions on mixing versions of deployment
+Definitions (DTDs) and XML schemas for Deployment Descriptors from previous
+versions of the Java(TM) EE and Jakarta(TM) EE specifications.
+All Jakarta EE 9 products are required
+to support the DTDs and schemas specified by Jakarta EE 8,
+as well as the schemas specified in this version of the specification. 
+This ensures that applications
+written to the previous version of the Jakarta EE specification can be deployed on
+products supporting the current version of this specification. 
+Support for versions of DTDs and schemas prior to Jakarta EE 8 is optional.
+In addition, there are no restrictions on mixing versions of supported deployment
 descriptors in a single application; any combination of valid deployment
 descriptor versions must be supported.
 
-=== Java EE 7 Application XML Schema
+=== Jakarta EE 9 schemas
+
+A new namespace has been specified,
+https://jakarta.ee/xml/ns/jakartaee/.
+Reference this page for the schema definitions defined for Jakarta EE 9.
+
+=== Java EE 8 / Jakarta EE 8 Schemas
+
+No updates to the schemas defined in previous releases of Java EE were required for Java EE 8 or Jakarta EE 8.
+
+=== Java EE 7 Schemas
+
+==== Java EE 7 Application XML Schema
 
 The XML grammar for a Java EE application
 deployment descriptor is defined by the Java EE application schema. The
@@ -27,32 +42,30 @@ is in general case sensitive. This means, for example, that
 _<role-name>Manager</role-name>_ is a different role than
 _<role-name>manager</role-name>_ .
 
-All valid Java EE application deployment
+All valid Java EE 7 application deployment
 descriptors must conform to the XML Schema definition, or the DTD or
 schema definition from a previous version of this specification. The
 deployment descriptor must be named _META-INF/application.xml_ in the
 _.ear_ file. Note that this name is case-sensitive.
-<<a3453, Java EE 7 Application
-XML Schema Structure>> shows a graphic representation of the structure of
+<<a3453, Java EE 7 Application XML Schema Structure>> shows a graphic representation of the structure of
 the Java EE application 7 XML Schema.
 
 [[a3453]]
 .Java EE 7 Application XML Schema Structure
 image::JavaEEapplication_schema_7.png[]
 
-_<<a3483, Java EE Application
-XML Schema Structure>>_ The XML Schema located at
+<<a3483, Java EE Application XML Schema Structure>> The XML Schema located at
 _http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd_ defines the XML
 grammar for a Java EE 7 application deployment descriptor.
 
-=== Common Java EE XML Schema Definitions
+==== Common Java EE 7 XML Schema Definitions
 
 The XML Schema located at
 _http://xmlns.jcp.org/xml/ns/javaee/javaee_7.xsd_ defines types that are
-used by many other Java EE deployment descriptor schemas, both in this
+used by many other Java EE 7 deployment descriptor schemas, both in this
 specification and in other specifications.
 
-=== Java EE 7 Application Client XML Schema
+==== Java EE 7 Application Client XML Schema
 
 The XML grammar for a Java EE application
 client deployment descriptor is defined by the Java EE
@@ -70,9 +83,8 @@ the application client’s _.jar_ file. Note that this name is
 case-sensitive.
 
 
-_<<a3462, Java EE 7 Application
-Client XML Schema Structure>>_ shows the structure of the Java EE
-application-client XML Schema. The Java EE application-client XML Schema
+<<a3462, Java EE 7 Application Client XML Schema Structure>> shows the structure of the Java EE
+application-client XML Schema. The Java EE 7 application-client XML Schema
 is located at
 _http://xmlns.jcp.org/xml/ns/javaee/application-client_7.xsd_ .
 
@@ -80,11 +92,13 @@ _http://xmlns.jcp.org/xml/ns/javaee/application-client_7.xsd_ .
 .Java EE 7 Application Client XML Schema Structure
 image::JavaEEapplication-client_schema_7.png[]
 
-=== Java EE 6 Application XML Schema
+=== Java EE 6 Schemas
 
-The XML grammar for a Java EE application
-deployment descriptor is defined by the Java EE application schema. The
-root element of the deployment descriptor for a Jaav EE application is
+==== Java EE 6 Application XML Schema
+
+The XML grammar for a Java EE 6 application
+deployment descriptor is defined by the Java EE 6 application schema. The
+root element of the deployment descriptor for a Java EE application is
 _application_ . The granularity of composition for Java EE application
 assembly is the Java EE module. A Java EE application deployment
 descriptor contains a name and description for the application and the
@@ -94,34 +108,32 @@ is in general case sensitive. This means, for example, that
 _<role-name>Manager</role-name>_ is a different role than
 _<role-name>manager</role-name>_ .
 
-All valid Java EE application deployment
+All valid Java EE 6 application deployment
 descriptors must conform to the XML Schema definition, or the DTD or
 schema definition from a previous version of this specification. The
 deployment descriptor must be named _META-INF/application.xml_ in the
 _.ear_ file. Note that this name is case-sensitive.
-<<a3467, Java EE Application XML
-Schema Structure>> shows a graphic representation of the structure of the
-Java EE application XML Schema.
+<<a3467, Java EE Application XML Schema Structure>> shows a graphic representation of the structure of the
+Java EE 6 application XML Schema.
 
 [[a3467]]
-.Java EE Application XML Schema Structure
+.Java EE 6 Application XML Schema Structure
 image::JavaEEapplication_schema.png[]
 
-_<<a3483, Java EE Application
-XML Schema Structure>>_ The XML Schema located at
+<<a3483, Java EE Application XML Schema Structure>> The XML Schema located at
 _http://java.sun.com/xml/ns/javaee/application_6.xsd_ defines the XML
-grammar for a Java EE application deployment descriptor.
+grammar for a Java EE 6 application deployment descriptor.
 
-=== Common Java EE XML Schema Definitions
+==== Common Java EE 6 XML Schema Definitions
 
 The XML Schema located at
 _http://java.sun.com/xml/ns/javaee/javaee_6.xsd_ defines types that are
 used by many other Java EE deployment descriptor schemas, both in this
 specification and in other specifications.
 
-=== Java EE 6 Application Client XML Schema
+==== Java EE 6 Application Client XML Schema
 
-The XML grammar for a Java EE application
+The XML grammar for a Java EE 6 application
 client deployment descriptor is defined by the Java EE
 application-client schema. The root element of the deployment descriptor
 for an application client is _application-client_ . The content of the
@@ -136,22 +148,22 @@ deployment descriptor must be named _META-INF/application-client.xml_ in
 the application client’s _.jar_ file. Note that this name is
 case-sensitive.
 
-
-_<<a3476, Java EE Application
-Client XML Schema Structure>>_ shows the structure of the Java EE
-application-client XML Schema. The Java EE application-client XML Schema
+<<a3476, Java EE Application Client XML Schema Structure>> shows the structure of the Java EE 6
+application-client XML Schema. The Java EE 6 application-client XML Schema
 is located at
 _http://java.sun.com/xml/ns/javaee/application-client_6.xsd_ .
 
 [[a3476]]
-.Java EE Application Client XML Schema Structure
+.Java EE 6 Application Client XML Schema Structure
 image::JavaEEapplication-client_schema.png[]
 
-=== Java EE 5 Application XML Schema
+=== Java EE 5 Schemas
 
-The XML grammar for a Java EE application
-deployment descriptor is defined by the Java EE application schema. The
-root element of the deployment descriptor for a Jaav EE application is
+==== Java EE 5 Application XML Schema
+
+The XML grammar for a Java EE 5 application
+deployment descriptor is defined by the Java EE 5 application schema. The
+root element of the deployment descriptor for a Java EE application is
 _application_ . The granularity of composition for Java EE application
 assembly is the Java EE module. A Java EE application deployment
 descriptor contains a name and description for the application and the
@@ -169,29 +181,28 @@ _META-INF/application.xml_ in the _.ear_ file. Note that this name is
 case-sensitive.
 
 
-_<<a3483, Java EE Application
-XML Schema Structure>>_ shows a graphic representation of the structure
-of the Java EE application XML Schema.
+<<a3483, Java EE 5 Application XML Schema Structure>> shows a graphic representation of the structure
+of the Java EE 5 application XML Schema.
 
 [[a3483]]
-.Java EE Application XML Schema Structure
+.Java EE 5 Application XML Schema Structure
 image::Platform_Spec-17.png[]
 
 The XML Schema located at
 _http://java.sun.com/xml/ns/javaee/application_5.xsd_ defines the XML
-grammar for a Java EE application deployment descriptor.
+grammar for a Java EE 5 application deployment descriptor.
 
-=== Common Java EE 5 XML Schema Definitions
+==== Common Java EE 5 XML Schema Definitions
 
 The XML Schema located at
 _http://java.sun.com/xml/ns/javaee/javaee_5.xsd_ defines types that are
-used by many other Java EE deployment descriptor schemas, both in this
+used by many other Java EE 5 deployment descriptor schemas, both in this
 specification and in other specifications.
 
-=== Java EE 5 Application Client XML Schema
+==== Java EE 5 Application Client XML Schema
 
-The XML grammar for a Java EE application
-client deployment descriptor is defined by the Java EE
+The XML grammar for a Java EE 5 application
+client deployment descriptor is defined by the Java EE 5
 application-client schema. The root element of the deployment descriptor
 for an application client is _application-client_ . The content of the
 XML elements is in general case sensitive. This means, for example, that
@@ -206,20 +217,21 @@ the application client’s _.jar_ file. Note that this name is
 case-sensitive.
 
 
-_<<a3492, Java EE Application
-Client XML Schema Structure>>_ shows the structure of the Java EE
+<<a3492, Java EE 5 Application Client XML Schema Structure>> shows the structure of the Java EE 5
 application-client XML Schema. The Java EE application-client XML Schema
 is located at
 _http://java.sun.com/xml/ns/javaee/application-client_5.xsd_ .
 
 [[a3492]]
-.Java EE Application Client XML Schema Structure
+.Java EE 5 Application Client XML Schema Structure
 image::Platform_Spec-18.png[]
 
-=== J2EE 1.4 Application XML Schema
+=== J2EE 1.4 Schemas
+
+==== J2EE 1.4 Application XML Schema
 
 This section provides the XML Schema for the
-J2EE application deployment descriptor. The XML grammar for a J2EE
+J2EE 1.4 application deployment descriptor. The XML grammar for a J2EE 1.4
 application deployment descriptor is defined by the _J2EE:application_
 schema. The granularity of composition for J2EE application assembly is
 the J2EE module. A _J2EE:application_ deployment descriptor contains a
@@ -230,36 +242,59 @@ sensitive. This means, for example, that
 _<role-name>Manager</role-name>_ is a different role than
 _<role-name>manager</role-name>_ .
 
-A valid J2EE application deployment descriptors
+A valid J2EE 1.4 application deployment descriptor
 may conform to the XML Schema definition below. The deployment
 descriptor must be named _META-INF/application.xml_ in the _.ear_ file.
 Note that this name is case-sensitive.
 
-
-_<<a3509, J2EE:application XML
-DTD Structure>>_ <<a3498, J2EE
-Application XML Schema Structure>> shows a graphic representation of the
+<<a3498, J2EE 1.4 Application XML Schema Structure>> shows a graphic representation of the
 structure of the J2EE application XML Schema.
 
 [[a3498]]
-.J2EE Application XML Schema Structure
+.J2EE 1.4 Application XML Schema Structure
 image::Platform_Spec-19.png[]
 
 The XML Schema that defines the XML grammar for
 a J2EE 1.4 application deployment descriptor is located at
 _http://java.sun.com/xml/ns/j2ee/application_1_4.xsd_ .
 
-=== Common J2EE 1.4 XML Schema Definitions
+==== Common J2EE 1.4 XML Schema Definitions
 
 The XML Schema that defines types that are used
 by many other J2EE 1.4 deployment descriptor schemas, both in this
 specification and in other specifications, is located at
 _http://java.sun.com/xml/ns/j2ee/j2ee_1_4.xsd_ .
 
-=== J2EE:application 1.3 XML DTD
+==== J2EE 1.4 Application Client XML Schema
+
+The XML grammar for a J2EE 1.4 application client
+deployment descriptor is defined by the J2EE 1.4 application-client schema.
+The root element of the deployment descriptor for an application client
+is _application-client_ . The content of the XML elements is in general
+case sensitive. This means, for example, that
+_<res-auth>Container</res-auth>_ must be used, rather than
+_<res-auth>container</res-auth>_ .
+
+A valid _application-client_ deployment
+descriptors may conform to the following XML Schema definition. The
+deployment descriptor must be named _META-INF/application-client.xml_ in
+the application client’s _.jar_ file. Note that this name is
+case-sensitive.
+
+<<a3523, J2EE 1.4 Application Client XML Schema Structure>> shows the structure of the
+J2EE 1.4 application-client XML Schema, which is available at
+_http://java.sun.com/xml/ns/j2ee/application-client_1_4.xsd_ .
+
+[[a3523]]
+.J2EE 1.4 Application Client XML Schema Structure
+image::Platform_Spec-22.png[]
+
+=== J2EE 1.3 DTDs
+
+==== J2EE:application 1.3 XML DTD
 
 This section provides the XML DTD for the J2EE
-1.3 application deployment descriptor. The XML grammar for a J2EE
+1.3 application deployment descriptor. The XML grammar for a J2EE 1.3
 application deployment descriptor is defined by the _J2EE:application_
 document type definition. The granularity of composition for J2EE
 application assembly is the J2EE module. A _J2EE:application_ deployment
@@ -281,71 +316,22 @@ The deployment descriptor must be named
 _META-INF/application.xml_ in the _.ear_ file.
 
 
-_<<a3509, J2EE:application XML
-DTD Structure>>_ shows a graphic representation of the structure of the
+<<a3509, J2EE:1.3 application XML DTD Structure>>_ shows a graphic representation of the structure of the
 _J2EE:application_ XML DTD.
 
 [[a3509]]
-.J2EE:application XML DTD Structure
+.J2EE:1.3 application XML DTD Structure
 image::JavaEEapplication_DTD.png[]
 
 The DTD that defines the XML grammar for a J2EE
 1.3 application deployment descriptor is available at
 http://java.sun.com/dtd/application_1_3.dtd.
 
-=== J2EE:application 1.2 XML DTD
-
-This section provides the XML DTD for the J2EE
-1.2 version of the application deployment descriptor. A valid J2EE 1.2
-application deployment descriptor may contain the following DOCTYPE
-declaration:
-
-<!DOCTYPE application PUBLIC "-//Sun
-Microsystems, Inc.//DTD J2EE Application 1.2//EN"
-"http://java.sun.com/j2ee/dtds/application_1_2.dtd">
-
-
-_<<a3516, J2EE:application XML
-DTD Structure>>_ shows a graphic representation of the structure of the
-_J2EE:application_ XML DTD.
-
-[[a3516]]
-.J2EE.application XML DTD Structure
-image::Platform_Spec-21.png[]
-
-The DTD that defines the XML grammar for a J2EE
-1.2 application deployment descriptor is available at
-http://java.sun.com/j2ee/dtds/application_1_2.dtd.
-
-=== J2EE 1.4 Application Client XML Schema
-
-The XML grammar for a J2EE application client
-deployment descriptor is defined by the J2EE application-client schema.
-The root element of the deployment descriptor for an application client
-is _application-client_ . The content of the XML elements is in general
-case sensitive. This means, for example, that
-_<res-auth>Container</res-auth>_ must be used, rather than
-_<res-auth>container</res-auth>_ .
-
-A valid _application-client_ deployment
-descriptors may conform to the following XML Schema definition. The
-deployment descriptor must be named _META-INF/application-client.xml_ in
-the application client’s _.jar_ file. Note that this name is
-case-sensitive.
-
-<<a3523, J2EE Application Client XML Schema Structure>> shows the structure of the
-J2EE 1.4 application-client XML Schema, which is available at
-_http://java.sun.com/xml/ns/j2ee/application-client_1_4.xsd_ .
-
-[[a3523]]
-.J2EE Application Client XML Schema Structure
-image::Platform_Spec-22.png[]
-
-=== J2EE:application-client 1.3 XML DTD
+==== J2EE:application-client 1.3 XML DTD
 
 This section describes the XML DTD for the J2EE
 1.3 version of the application client deployment descriptor. The XML
-grammar for a J2EE application client deployment descriptor is defined
+grammar for a J2EE 1.3 application client deployment descriptor is defined
 by the _J2EE:application-client_ document type definition. The root
 element of the deployment descriptor for an application client is
 _application-client_ . The content of the XML elements is in general
@@ -364,16 +350,39 @@ The deployment descriptor must be named
 _META-INF/application-client.xml_ in the application client’s _.jar_
 file.
 
-
-_<<a3530, J2EE:application-client XML DTD Structure>>_ shows the structure of the
+<<a3530, J2EE:1.3 application-client XML DTD Structure>> shows the structure of the
 _J2EE:application-client_ XML DTD, which is available at
 http://java.sun.com/dtd/application-client_1_3.dtd.
 
 [[a3530]]
-.J2EE:application-client XML DTD Structure
+.J2EE:1.3 application-client XML DTD Structure
 image::Platform_Spec-23.png[]
 
-=== J2EE:application-client 1.2 XML DTD
+=== J2EE 1.2 DTDs
+
+==== J2EE:application 1.2 XML DTD
+
+This section provides the XML DTD for the J2EE
+1.2 version of the application deployment descriptor. A valid J2EE 1.2
+application deployment descriptor may contain the following DOCTYPE
+declaration:
+
+<!DOCTYPE application PUBLIC "-//Sun
+Microsystems, Inc.//DTD J2EE Application 1.2//EN"
+"http://java.sun.com/j2ee/dtds/application_1_2.dtd">
+
+<<a3516, J2EE:1.2 application XML DTD Structure>>_ shows a graphic representation of the structure of the
+_J2EE:application_ XML DTD.
+
+[[a3516]]
+.J2EE.1.2 application XML DTD Structure
+image::Platform_Spec-21.png[]
+
+The DTD that defines the XML grammar for a J2EE
+1.2 application deployment descriptor is available at
+http://java.sun.com/j2ee/dtds/application_1_2.dtd.
+
+==== J2EE:application-client 1.2 XML DTD
 
 This section describes the XML DTD for the J2EE
 1.2 version of the application client deployment descriptor. A valid
@@ -384,11 +393,10 @@ DOCTYPE declaration:
 Microsystems, Inc.//DTD J2EE Application Client 1.2//EN"
 "http://java.sun.com/j2ee/dtds/application-client_1_2.dtd">
 
-
-_<<a3536, J2EE:application-client XML DTD Structure>>_ shows the structure of the
+<<a3536, J2EE:1.2 application-client XML DTD Structure>> shows the structure of the
 _J2EE:application-client_ XML DTD, which is available at
 http://java.sun.com/j2ee/dtds/application-client_1_2.dtd.
 
 [[a3536]]
-.J2EE:application-client XML DTD Structure
+.J2EE:1.2 application-client XML DTD Structure
 image::Platform_Spec-24.png[]

--- a/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
+++ b/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
@@ -30,9 +30,9 @@ Reference this page, https://jakarta.ee/xml/ns/jakartaee/#8, for the schema defi
 
 ==== Java EE 7 Application XML Schema
 
-The XML grammar for a Java EE application
-deployment descriptor is defined by the Java EE application schema. The
-root element of the deployment descriptor for a Jaav EE application is
+The XML grammar for a Java EE 7 application
+deployment descriptor is defined by the Java EE 7 application schema. The
+root element of the deployment descriptor for a Java EE application is
 _application_ . The granularity of composition for Java EE application
 assembly is the Java EE module. A Java EE application deployment
 descriptor contains a name and description for the application and the
@@ -54,7 +54,7 @@ the Java EE application 7 XML Schema.
 .Java EE 7 Application XML Schema Structure
 image::JavaEEapplication_schema_7.png[]
 
-<<a3483, Java EE Application XML Schema Structure>> The XML Schema located at
+<<a3483, Java EE 7 Application XML Schema Structure>> The XML Schema located at
 _http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd_ defines the XML
 grammar for a Java EE 7 application deployment descriptor.
 
@@ -67,8 +67,8 @@ specification and in other specifications.
 
 ==== Java EE 7 Application Client XML Schema
 
-The XML grammar for a Java EE application
-client deployment descriptor is defined by the Java EE
+The XML grammar for a Java EE 7 application
+client deployment descriptor is defined by the Java EE 7
 application-client schema. The root element of the deployment descriptor
 for an application client is _application-client_ . The content of the
 XML elements is in general case sensitive. This means, for example, that
@@ -83,7 +83,7 @@ the application client’s _.jar_ file. Note that this name is
 case-sensitive.
 
 
-<<a3462, Java EE 7 Application Client XML Schema Structure>> shows the structure of the Java EE
+<<a3462, Java EE 7 Application Client XML Schema Structure>> shows the structure of the Java EE 7
 application-client XML Schema. The Java EE 7 application-client XML Schema
 is located at
 _http://xmlns.jcp.org/xml/ns/javaee/application-client_7.xsd_ .
@@ -113,14 +113,14 @@ descriptors must conform to the XML Schema definition, or the DTD or
 schema definition from a previous version of this specification. The
 deployment descriptor must be named _META-INF/application.xml_ in the
 _.ear_ file. Note that this name is case-sensitive.
-<<a3467, Java EE Application XML Schema Structure>> shows a graphic representation of the structure of the
+<<a3467, Java EE 6 Application XML Schema Structure>> shows a graphic representation of the structure of the
 Java EE 6 application XML Schema.
 
 [[a3467]]
 .Java EE 6 Application XML Schema Structure
 image::JavaEEapplication_schema.png[]
 
-<<a3483, Java EE Application XML Schema Structure>> The XML Schema located at
+<<a3483, Java EE 6 Application XML Schema Structure>> The XML Schema located at
 _http://java.sun.com/xml/ns/javaee/application_6.xsd_ defines the XML
 grammar for a Java EE 6 application deployment descriptor.
 
@@ -148,7 +148,7 @@ deployment descriptor must be named _META-INF/application-client.xml_ in
 the application client’s _.jar_ file. Note that this name is
 case-sensitive.
 
-<<a3476, Java EE Application Client XML Schema Structure>> shows the structure of the Java EE 6
+<<a3476, Java EE 6 Application Client XML Schema Structure>> shows the structure of the Java EE 6
 application-client XML Schema. The Java EE 6 application-client XML Schema
 is located at
 _http://java.sun.com/xml/ns/javaee/application-client_6.xsd_ .
@@ -314,7 +314,6 @@ Microsystems, Inc.//DTD J2EE Application 1.3//EN"
 
 The deployment descriptor must be named
 _META-INF/application.xml_ in the _.ear_ file.
-
 
 <<a3509, J2EE:1.3 application XML DTD Structure>>_ shows a graphic representation of the structure of the
 _J2EE:application_ XML DTD.

--- a/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
+++ b/specification/src/main/asciidoc/platform/PreviousVersionDeploymentDescriptors.adoc
@@ -18,13 +18,13 @@ descriptor versions must be supported.
 
 === Jakarta EE 9 schemas
 
-A new namespace has been specified,
-https://jakarta.ee/xml/ns/jakartaee/.
-Reference this page for the schema definitions defined for Jakarta EE 9.
+A new namespace has been specified for Jakarta EE 9, https://jakarta.ee/xml/ns/jakartaee/.
+Reference this page, https://jakarta.ee/xml/ns/jakartaee/#9, for the schema definitions defined for Jakarta EE 9.
 
 === Java EE 8 / Jakarta EE 8 Schemas
 
 No updates to the schemas defined in previous releases of Java EE were required for Java EE 8 or Jakarta EE 8.
+Reference this page, https://jakarta.ee/xml/ns/jakartaee/#8, for the schema definitions defined for Java EE 8 and Jakarta EE 8.
 
 === Java EE 7 Schemas
 


### PR DESCRIPTION
Update Previous DD section per Jakarta EE 9 release plan and our documented Platform decisions regarding previous version support.
https://eclipse-ee4j.github.io/jakartaee-platform/minutes/2020-01-28.html

I also cleaned up the organization of this section, dividing it up by each major version of J2EE, Java EE, and Jakarta EE.  Also, clarified what specific version each section was referring to.

Signed-off-by: Kevin Sutter <kwsutter@gmail.com>