### PR TITLE
update Interoperability section based on Jakarta EE 9 release plan

### DIFF
--- a/specification/src/main/asciidoc/platform/Interoperability.adoc
+++ b/specification/src/main/asciidoc/platform/Interoperability.adoc
@@ -35,7 +35,7 @@ The interoperability requirements for the
 current Jakarta EE platform release allow:
 
 * Jakarta EE applications to connect to legacy
-systems using CORBA or low-level socket interfaces.
+systems using CORBAfootnote:removed9[Removed from Jakarta EE 9.] or low-level socket interfaces.
 * Jakarta EE applications to connect to other Java
 Jakarta applications across multiple Jakarta EE products, whether from different
 Product Providers or from the same Provider, and multiple Jakarta EE
@@ -44,7 +44,7 @@ platforms.
 In this version of the specification,
 interoperability between Jakarta EE applications running in different
 platforms is accomplished through the HTTP protocol, possibly using SSL,
-or the Jakarta Enterprise Beans interoperability protocol based on IIOP.
+or the Jakarta Enterprise Beans interoperability protocol based on IIOPfootnote:removed9[].
 
 === Interoperability Protocols
 
@@ -56,8 +56,8 @@ specification requires support for the following groups of protocols and
 formats:
 
 * Internet and web protocols
-* OMG protocols
-* Java technology protocols
+* OMG protocolsfootnote:removed9[]
+* Java technology protocols **TODO** JRMP may also be removed?
 * Data formats
 
 Most of these protocols and formats are
@@ -90,14 +90,16 @@ are required as part of the Jakarta Enterprise Beans interoperability protocol i
 specification.
 * SOAP 1.1—SOAP is a presentation layer
 protocol for the exchange of XML messages. Support for SOAP layered on
-HTTP is required, as described in the Jakarta XML-based RPC and Jakarta XML Web Services specifications.
+HTTP is optional, as described in the Jakarta XML-based RPCfootnote:removed9[] and 
+Jakarta XML Web Servicesfootnote:optional9[Made optional in Jakarta EE 9] specifications.
 * SOAP 1.2—SOAP 1.2 is the version of the SOAP
-protocol standardized through W3C and supported by Jakarta XML Web Services.
+protocol standardized through W3C and supported by Jakarta XML Web Servicesfootnote:optional9[].
 * WS-I Basic Profile 1.1—The WS-I Basic
 Profile, in combination with the Simple SOAP Binding Profile and
 Attachment Profile, describes interoperability requirements for the use
 of SOAP 1.1, WSDL 1.1, and MIME-based SOAP with Attachments. It is
-required by the Jakarta XML-based RPC and Jakarta XML Web Services specifications.
+optional as defined by the Jakarta XML-based RPCfootnote:removed9[] and 
+Jakarta XML Web Servicesfootnote:optional9[] specifications.
 * WebSocket protocol—The WebSocket protocol
 enables two-way communication layered over TCP. It enables
 bi-directional communication over a single connection established by an
@@ -105,40 +107,15 @@ initial HTTP handshake and upgrade request. The WebSocket protocol has
 been standardized by IETF under RFC 6455.
 
 [[a2875]]
-==== OMG Protocols (Proposed Optional)
+==== OMG Protocols (Removed)
 
-This specification requires the a full Jakarta EE
-product to support the following Object Management Group (OMG) based
-protocols:
-
-* IIOP (Internet Inter-ORB Protocol)—Supported
-by Java IDL and RMI-IIOP in Java SE. Java IDL provides standards-based
-interoperability and connectivity through the Common Object Request
-Broker Architecture (CORBA). CORBA specifies the Object Request Broker
-(ORB) which allows applications to communicate with each other
-regardless of location. This interoperability is delivered through IIOP,
-and is typically found in an intranet setting. IIOP can be used as an
-RMI protocol using the RMI-IIOP technology. IIOP is defined in Chapters
-13 and 15 of the CORBA 2.3.1 specification, available at
-_http://omg.org/cgi-bin/doc?formal/99-10-07_ .
-* Jakarta Enterprise Beans interoperability protocol—The Jakarta Enterprise Beans
-interoperability protocol is based on IIOP (GIOP 1.2) and the CSIv2
-CORBA Secure Interoperability specification. The Jakarta Enterprise Beans interoperability
-protocol is defined in the Jakarta Enterprise Beans specification.
-* CORBA Interoperable Naming Service
-protocol—The COSNaming-based INS protocol is an IIOP-based protocol for
-accessing a name service. The Jakarta Enterprise Beans interoperability protocol requires the
-use of the INS protocol for lookup of Jakarta Enterprise Beans objects using the JNDI API. In
-addition, it must be possible to use the Java IDL COSNaming API to
-access the INS name service. All Jakarta EE products must provide a name
-service that meets the requirements of the Interoperable Naming Service
-specification, available at
-_http://omg.org/cgi-bin/doc?formal/2000-06-19_ . This name service may
-be provided as a separate name server or as a protocol bridge or gateway
-to another name service. Either approach is consistent with this
-specification.
+Jakarta EE 9 removed the support for the Object Management Group (OMG) based protocols.
+Reference <<a2333, Removed Jakarta Technologies>> for more details.
 
 ==== Java Technology Protocols
+
+**TODO** JRMP is a protocol that needs to be fleshed out due to the removal of CORBA
+and IIOP from the EJB interop specification.
 
 This specification requires the Jakarta EE platform
 to support the JRMP protocol, which is the Java technology-specific
@@ -169,7 +146,7 @@ The following data formats must be supported:
 
 * XML 1.0—The XML format can be used to
 construct documents, RPC messages, etc. The JAXP API provides support
-for processing XML format data. The Jakarta XML-based RPC API provides support for XML
+for processing XML format data. The Jakarta XML-based RPCfootnote:removed9[] API provides support for XML
 RPC messages, as well as a mapping between Java classes and XML.
 * JSON—JSON is a language-neutral plain text
 format commonly used to transfer structured data between a server and


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Modified references and created footnotes for Removed and Optional specifications and features.  Removed the OMG section and replaced it with a statement that this was removed in Jakarta EE 9.

Created a **TODO** for the JRMP section.