### PR TITLE
correct efsl syntax and remove extraneous quotemarks

### DIFF
--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -34,7 +34,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php"
+  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -55,7 +55,7 @@ The notice is:
 
 "Copyright (c) 2018,2020 Eclipse Foundation. This software or
 document includes material copied from or derived from 
-Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/."
+Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/[]."
 
 ==== Disclaimers
 

--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -24,14 +24,13 @@ module type not supported by a product based on a particular Jakarta EE
 profile should be understood to not apply to such a product.
 
 
-_<<a2899, Jakarta EE Deployment>>_
+<<a2899, Jakarta EE Deployment>>
 shows the composition model for Jakarta EE deployment units and includes
 the optional use of alternate deployment descriptors by the application
 package to preserve any digital signatures of the original Jakarta EE
 modules. An alternate deployment descriptor may also be provided
 external to the application package as described in
-<<a3125, Assembling a Jakarta EE
-Application>>.”
+<<a3125, Assembling a Jakarta EE Application>>.
 
 [[a2899]]
 .Jakarta EE Deployment
@@ -47,8 +46,8 @@ as stand-alone units or can be assembled with a Jakarta EE application
 deployment descriptor and deployed as a Jakarta EE application.
 
 
-_<<a2903, Jakarta EE Application
-Life Cycle>>_ shows the life cycle of a Jakarta EE application.
+<<a2903, Jakarta EE Application Life Cycle>> 
+shows the life cycle of a Jakarta EE application.
 
 [[a2903]]
 .Jakarta EE Application Life Cycle
@@ -96,7 +95,7 @@ deployed as a stand-alone Jakarta EE module without an application level
 deployment descriptor and represents a valid Jakarta EE application.
 * Jakarta EE modules may express dependencies on
 libraries as described below in
-<<a2945, Library Support>>.”
+<<a2945, Library Support>>.
 
 All Jakarta EE modules have a name. The name can
 be explicitly set in the deployment descriptor for the module. If not
@@ -150,7 +149,7 @@ extension. A minimal Jakarta EE application package will only contain Jakarta
 EE modules and, optionally, the application deployment descriptor. A
 Jakarta EE application package may also include libraries referenced by
 Jakarta EE modules (using the _Class-Path_ mechanism described below in
-<<a2945, Library Support>>”),
+<<a2945, Library Support>>),
 help files, and documentation to aid the deployer.
 
 The deployment of a portable Jakarta EE
@@ -164,8 +163,7 @@ The Jakarta EE application deployment descriptor
 represents the top level view of a Jakarta EE application’s contents. The
 Jakarta EE application deployment descriptor is specified by an XML schema
 or document type definition (see
-<<a3203, Jakarta EE Application XML
-Schema>>”).
+<<a3203, Jakarta EE Application XML Schema>>).
 
 In certain cases, a Jakarta EE application will
 need customization before it can be deployed into the enterprise. New
@@ -215,8 +213,7 @@ resource of the required type.
 
 Some resources have default mapping rules
 specified; see sections <<a2009, Default Data Source>>, <<a2025, Default JMS Connection Factory>>, and
-<<a2042, Default Concurrency
-Utilities Objects>>. By default, a product must map otherwise unmapped
+<<a2042, Default Concurrency Utilities Objects>>. By default, a product must map otherwise unmapped
 resources using these default rules. A product may include an option to
 disable or override these default mapping rules.
 
@@ -521,7 +518,7 @@ types of class loaders used or the
 hierarchical arrangement of class loaders, if any. Portable applications
 must not depend on the order in which classes and resources are loaded.
 Applications should use the techniques described in
-<<a2966, Dynamic Class Loading>>”
+<<a2966, Dynamic Class Loading>>
 if they need to load classes dynamically.
 
 In addition to the required classes specified
@@ -540,7 +537,7 @@ of the Java security model.
 Note that while libraries must be accessible
 to application classes as described below, it may be necessary to use
 the techniques described in
-<<a2966, Dynamic Class Loading>>”
+<<a2966, Dynamic Class Loading>>
 if libraries need to access classes packaged in the application modules.
 
 [[a3046]]
@@ -560,13 +557,13 @@ _WEB-INF/lib_ directory of the containing war file, but not any
 subdirectories.
 * The transitive closure of any libraries
 referenced by the above jar files (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the war file itself (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 specified by or referenced by the containing ear file (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The contents of all jar files included in
 any resource adapter archives (rar files) included in the same ear file.
 * The contents of all jar files included in
@@ -577,16 +574,15 @@ resource references in the module.
 each resource adapter archive (rar file) deployed separately to the
 application server, if any jar file in that rar file is used to satisfy
 any reference from the module using the Extension Mechanism Architecture
-(as specified in <<a2945, Library Support>>”).
+(as specified in <<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the rar files themselves (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the web container.
+<<a2159, Jakarta EE Technologies>> for the web container.
 * All Java SE 8 API classes.
 
 
@@ -604,19 +600,18 @@ in the same ear file.
 specified by the above Jakarta Enterprise Beans jar files.
 * The transitive closure of any libraries
 referenced by the above Jakarta Enterprise Beans jar files and client jar files (as specified
-in <<a2945, Library Support>>”).
+in <<a2945, Library Support>>).
 * The contents of any jar files included in
 any resource adapter archives (rar files) deployed separately to the
 application server.
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the rar files above themselves (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the containers other than the web container.
+<<a2159, Jakarta EE Technologies>> for the containers other than the web container.
 * Any installed libraries available in the
 application server.
 * Other classes or resources contained in the
@@ -643,10 +638,10 @@ access to the following classes and resources.
 * The content of the Jakarta Enterprise Beans jar file.
 * The transitive closure of any libraries
 referenced by the Jakarta Enterprise Beans jar file (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 specified by or referenced by the containing ear file (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The contents of all jar files included in
 any resource adapter archives (rar files) included in the same ear file.
 * The contents of all jar files included in
@@ -657,16 +652,15 @@ resource references in the module.
 each resource adapter archive (rar file) deployed separately to the
 application server, if any jar file in that rar file is used to satisfy
 any reference from the module using the Extension Mechanism Architecture
-(as specified in <<a2945, Library Support>>”).
+(as specified in <<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
-<<a2945, Library Support>>”.
+<<a2945, Library Support>>.
 * The transitive closure of any libraries
 referenced by the rar files themselves (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the Jakarta Enterprise Beans container.
+<<a2159, Jakarta EE Technologies>> for the Jakarta Enterprise Beans container.
 * All Java SE 8 API classes.
 
 
@@ -678,27 +672,25 @@ resources.
 
 * The classes and resources accessible to any
 web modules included in the same ear file, as described in
-<<a3046, Web Container Class
-Loading Requirements>>” above.
+<<a3046, Web Container Class Loading Requirements>>” above.
 * The content of any Jakarta Enterprise Beans jar files included
 in the same ear file.
 * The content of any client jar files
 specified by the above Jakarta Enterprise Beans jar files.
 * The transitive closure of any libraries
 referenced by the above Jakarta Enterprise Beans jar files and client jar files (as specified
-in <<a2945, Library Support>>”).
+in <<a2945, Library Support>>).
 * The contents of any jar files included in
 any resource adapter archives (rar files) deployed separately to the
 application server.
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the rar files above themselves (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the containers other than the Jakarta Enterprise Beans container.
+<<a2159, Jakarta EE Technologies>> for the containers other than the Jakarta Enterprise Beans container.
 * Any installed libraries available in the
 application server.
 * Other classes or resources contained in the
@@ -726,13 +718,12 @@ container must have access to the following classes and resources.
 file.
 * The transitive closure of any libraries
 referenced by the above jar file (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The transitive closure of any libraries
 specified by or referenced by the containing ear file (as specified in
-<<a2945, Library Support>>”).
+<<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the application client container.
+<<a2159, Jakarta EE Technologies>> for the application client container.
 * All Java SE 8 API classes.
 
 
@@ -743,8 +734,7 @@ Portable applications must not depend on having or not having access to
 these classes or resources.
 
 * The Jakarta EE API classes specified in
-<<a2159, Jakarta EE
-Technologies>> for the containers other than the application client
+<<a2159, Jakarta EE Technologies>> for the containers other than the application client
 container.
 * Any installed libraries available in the
 application server.
@@ -795,7 +785,7 @@ descriptors.
 The deployment descriptors for the Jakarta EE
 modules must be edited to link internally satisfied dependencies and
 eliminate any redundant security role names. An optional element
-_alt-dd_ (described in <<a3203, Jakarta EE Application XML Schema>>”) may be used when it is desirable to
+_alt-dd_ (described in <<a3203, Jakarta EE Application XML Schema>>) may be used when it is desirable to
 preserve the original deployment descriptor. The element _alt-dd_
 specifies an alternate deployment descriptor to use at deployment time.
 The edited copy of the deployment descriptor file may be saved in the
@@ -816,8 +806,7 @@ component dependency, there must only be one corresponding component
 that fulfills that dependency in the scope of the application.
 . For each _ejb-link_ , there must be only one
 matching _ejb-name_ in the scope of the entire application (see
-<<a936, Enterprise JavaBeans™
-(EJB) References>>”).
+<<a936, Enterprise JavaBeans™ (EJB) References>>).
 . Dependencies that are not linked to internal
 components must be handled by the Deployer as external dependencies that
 must be met by resources previously installed on the platform. External
@@ -956,8 +945,7 @@ the class namespace of any application depending on the level of
 isolation supported by the Jakarta EE product.
 
 As described in
-<<a149, Jakarta EE Product
-Packaging>>”, the Jakarta EE product might depend on external services to
+<<a149, Jakarta EE Product Packaging>>, the Jakarta EE product might depend on external services to
 meet the requirements of this specification. While the Jakarta EE product
 is not required to assure the availability of these services, it is
 required to ensure that these services have been configured for use.
@@ -1035,14 +1023,11 @@ deployment information; a deployment tool must examine the application
 class files for annotations that specify deployment information.
 
 If annotations are being processed (as
-required by <<a3318, Deployment
-Descriptor Processing Requirements>>, Jakarta Servlet Table 8-1, and Jakarta Enterprise Beans Tables
+required by <<a3318, Deployment Descriptor Processing Requirements>>, Jakarta Servlet Table 8-1, and Jakarta Enterprise Beans Tables
 16 and 17), _at least_ all of the classes specified in
-<<a651, Component classes
-supporting injection>> must be scanned for annotations that specify
+<<a651, Component classes supporting injection>> must be scanned for annotations that specify
 deployment information. As specified in section
-<<a3179, Deploying a Jakarta EE
-Application>>, all classes that can be used by the application may
+<<a3179, Deploying a Jakarta EE Application>>, all classes that can be used by the application may
 optionally be scanned for these annotations. (These are the annotations
 that specify information equivalent to what can be specified in a
 deployment descriptor. This requirement says nothing about the
@@ -1145,12 +1130,12 @@ rules to determine the modules included in the application.
 . All files in the application package with a
 filename extension of _.war_ are considered web modules. The context
 root of the web module is the module name (see
-<<a2904, Component Creation>>”).
+<<a2904, Component Creation>>).
 . All files in the application package with a
 filename extension of _.rar_ are considered resource adapters.
 . A directory named _lib_ is considered to be
 the library directory, as described in
-<<a2948, Bundled Libraries>>.”
+<<a2948, Bundled Libraries>>.
 . For all files in the application package
 with a filename extension of _.jar_ , but not contained in the _lib_
 directory, do the following:
@@ -1179,7 +1164,7 @@ Jakarta Beans, Jakarta Servlet, Jakarta Connector and application client
 specifications for the required location and name of the deployment
 descriptor for each component type. Deployment descriptors are optional
 for all module types. (The application client specification is
-<<a3294, Application Clients>>”.)
+<<a3294, Application Clients>>.)
 . If the module deployment descriptor is
 absent, or is present and is a Java EE 5 or later version descriptor and
 the _metadata-complete_ attribute is not set to _true_ , the deployment
@@ -1296,8 +1281,7 @@ _<role-name>manager</role-name>_ .
 All valid Jakarta EE application deployment
 descriptors must conform to the XML Schema definition, or the DTD or
 schema definition from a previous version of this specification. (See
-<<a3447, Previous Version
-Deployment Descriptors>>.) The deployment descriptor must be named
+<<a3447, Previous Version Deployment Descriptors>>.) The deployment descriptor must be named
 _META-INF/application.xml_ in the _.ear_ file. Note that this name is
 case-sensitive. The XML Schema located at
 _https://jakarta.ee/xml/ns/jakartaee/application_9.xsd_ defines the XML

--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -672,7 +672,7 @@ resources.
 
 * The classes and resources accessible to any
 web modules included in the same ear file, as described in
-<<a3046, Web Container Class Loading Requirements>>” above.
+<<a3046, Web Container Class Loading Requirements>> above.
 * The content of any Jakarta Enterprise Beans jar files included
 in the same ear file.
 * The content of any client jar files

--- a/specification/src/main/asciidoc/platform/ApplicationClients.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationClients.adoc
@@ -54,8 +54,7 @@ gather authentication data, the container must provide an appropriate
 user interface. In addition, an application client may provide a class
 that implements the _javax.security.auth.callback.CallbackHandler_
 interface and specify the class name in its deployment descriptor (see
-<<a3399, Jakarta EE Application
-Client XML Schema>>” for details). The Deployer may override the callback
+<<a3399, Jakarta EE Application Client XML Schema>> for details). The Deployer may override the callback
 handler specified by the application and use the container’s default
 authentication user interface instead.
 
@@ -74,8 +73,7 @@ Application clients typically execute in an
 environment with a SecurityManager installed, and have similar security
 permission requirements as servlets. The security permission
 requirements are described fully in
-<<a2339, Java Platform, Standard
-Edition (Java SE) Requirements>>.”
+<<a2339, Java Platform, Standard Edition (Java SE) Requirements>>.
 
 === Transactions
 
@@ -95,7 +93,7 @@ As with all Jakarta EE components, application
 clients use JNDI to look up enterprise beans, get access to resource
 managers, reference configurable parameters set at deployment time, and
 so on. Application clients use the _java:_ JNDI namespace to access
-these items (see <<a567, Resources, Naming, and Injection>>” for details).
+these items (see <<a567, Resources, Naming, and Injection>> for details).
 
 Injection is also supported for the
 application client main class. Because the application client container
@@ -220,8 +218,7 @@ annotations that specify such deployment information in the class files
 packaged in the application client jar file. Such annotations must also
 be ignored when processing the class files that are available to the
 application client module for the deployment of this module according to
-<<a3179, Deploying a Jakarta EE
-Application>>”.
+<<a3179, Deploying a Jakarta EE Application>>.
 
 Note that a _"true"_ value for the
 _metadata-complete_ attribute does _not_ preempt the processing of _all_
@@ -303,12 +300,12 @@ _<res-auth>container</res-auth>_ .
 All valid _application-client_ deployment
 descriptors must conform to the XML Schema definition, or to a DTD or
 schema definition from a previous version of this specification. (See
-<<a3447, Previous Version Deployment Descriptors>>.”) The deployment descriptor must be named
+<<a3447, Previous Version Deployment Descriptors>>.) The deployment descriptor must be named
 _META-INF/application-client.xml_ in the application client’s _.jar_
 file. Note that this name is case-sensitive.
 
 
-_<<a3404, Jakarta EE Application Client XML Schema Structure>>_ shows the structure of the Jakarta EE
+<<a3404, Jakarta EE Application Client XML Schema Structure>> shows the structure of the Jakarta EE
 application-client XML Schema. The Jakarta EE application-client XML Schema
 is located at
 _https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd_.

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -475,7 +475,7 @@ different permissions than those described in
 <<a2366, Jakarta EE Security Permissions Set>>.
 
 As defined in
-<<a2496, Declaring Permissions Required by Application Components>>,” a component provider may declare
+<<a2496, Declaring Permissions Required by Application Components>>, a component provider may declare
 the permissions required by the application classes and libraries
 packaged in a module. When a component provider has declared the
 permissions required by a module, on successful deployment of the
@@ -518,7 +518,7 @@ of the installation environment, application component providers should
 declare all Java security permissions required by their application
 components.
 
-<<a2496, Declaring Permissions Required by Application Components>>,” defines the
+<<a2496, Declaring Permissions Required by Application Components>>, defines the
 mechanism(s) by which required permissions may be declared.
 
 Note that, while FilePermissions or
@@ -929,7 +929,7 @@ load JDBC drivers directly. Instead, they should use the technique
 recommended in the JDBC specification and perform a JNDI lookup to
 locate a _DataSource_ object. The JNDI name of the _DataSource_ object
 should be chosen as described in
-<<a1120, Resource Manager Connection Factory References>>.” The Jakarta EE platform must be able to
+<<a1120, Resource Manager Connection Factory References>>. The Jakarta EE platform must be able to
 supply a _DataSource_ that does not require the application to supply
 any authentication information when obtaining a database connection. Of
 course, applications may also supply a user name and password when

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -7,7 +7,7 @@ Jakarta™ EE Platform.
 
 The required relationships of architectural
 elements of the Jakarta EE platform are shown in
-_<<a45, Jakarta EE Architecture Diagram>>_.
+<<a45, Jakarta EE Architecture Diagram>>.
 Note that this figure shows the logical relationships of the
 elements; it is not meant to imply a physical partitioning of the
 elements into separate machines, processes, address spaces, or virtual
@@ -212,7 +212,7 @@ formats for the packaging of application components for deployment.
 
 The containers are implemented by a Jakarta EE
 Product Provider. See the description of the Product Provider role in
-<<a162, Jakarta EE Product Provider>>”.
+<<a162, Jakarta EE Product Provider>>.
 
 This specification defines a set of standard
 services that each Jakarta EE product must support. These standard services
@@ -255,7 +255,7 @@ database is accessible from web components, enterprise beans, and
 application client components. The database need not be accessible from
 applets. The Jakarta EE Product Provider must also provide a preconfigured,
 default data source for use by the application in accessing this
-database. See <<a2009, Default Data Source>>”.
+database. See <<a2009, Default Data Source>>.
 
 [[a84]]
 === Jakarta EE Standard Services
@@ -290,13 +290,13 @@ and a resource manager used at the Jakarta EE SPI level.
 
 Support for CORBA, including use of IIOP and
 Java IDL, was Removed as of Jakarta EE 9. See
-<<a2331, Removed Java Technologies>>.”
+<<a2331, Removed Java Technologies>>.
 
 ==== Java IDL (Removed)
 
 Support for CORBA, including use of IIOP and
 Java IDL, was Removed as of Jakarta EE 9. See
-<<a2331, Removed Java Technologies>>.”
+<<a2331, Removed Java Technologies>>.
 
 ==== JDBC™ API
 
@@ -330,7 +330,7 @@ implements both point-to-point messaging as well as publish-subscribe
 messaging. The Jakarta EE Product Provider must also provide a
 preconfigured, default Jakarta Messaging connection factory for use by the application
 in accessing this JMS provider. See
-<<a2025, Default Jakarta Messaging Connection Factory>>”.
+<<a2025, Default Jakarta Messaging Connection Factory>>.
 
 ==== Java Naming and Directory Interface™ (JNDI)
 
@@ -442,7 +442,7 @@ web services and is a follow-on to Jakarta XML-based RPCfootnote:[Removed from J
 Jakarta XML Web Services offers extensive web
 services functionality, with support for multiple bindings/protocols.
 Support for Jakarta XML-based RPC has been removed from the Platform as of Jakarta EE 9. See
-<<a2331, Removed Java Technologies>>”.
+<<a2331, Removed Java Technologies>>.
 
 Jakarta XML Web Services and Jakarta XML Binding
 define the mapping between Java classes and XML as used
@@ -454,7 +454,7 @@ in Jakarta EE, as well as the implementation of web service endpoints using
 enterprise beans. The XML Web Services Metadata specification defines Java
 language annotations that make it easier to develop web services. The
 Jakarta XML Registries support has been removed from the Platform as of Jakarta EE
-9. See <<a2331, Removed Java Technologies>>”.
+9. See <<a2331, Removed Java Technologies>>.
 
 ==== Jakarta JSON Processing
 
@@ -509,7 +509,7 @@ interoperability with components that are not a part of the Jakarta EE
 platform, such as external web or CORBA services.
 
 
-_<<a142, Jakarta EE Interoperability>>_ illustrates the interoperability facilities of the
+<<a142, Jakarta EE Interoperability>> illustrates the interoperability facilities of the
 Jakarta EE platform. (The directions of the arrows indicate the
 client/server relationships of the components.)
 
@@ -594,9 +594,9 @@ services.
 This specification describes a minimum set of
 facilities available to all Jakarta EE products. A Jakarta EE profile may
 include some or all of these facilities, as described in
-<<a3212, Profiles>>”. Products
+<<a3212, Profiles>>. Products
 implementing the full Jakarta EE platform must provide all of them (see
-<<a3252, Full Jakarta EE Product Requirements>>”). 
+<<a3252, Full Jakarta EE Product Requirements>>). 
 Most Jakarta EE products will provide facilities beyond
 the minimum required by this specification. This specification includes
 only a few limits to the ability of a product to provide extensions. In
@@ -658,9 +658,9 @@ implementation-specific way.
 
 A Jakarta EE Product Provider must provide
 application deployment and management tools. Deployment tools enable a
-Deployer (see <<a170, Deployer>>”) to deploy application components on the Jakarta EE product.
+Deployer (see <<a170, Deployer>>) to deploy application components on the Jakarta EE product.
 Management tools allow a System Administrator (see
-<<a178, System Administrator>>”)
+<<a178, System Administrator>>)
 to manage the Jakarta EE product and the applications deployed on the Jakarta
 EE product. The form of these tools is not prescribed by this
 specification.
@@ -765,7 +765,7 @@ provider as defined by the Jakarta Authorization specification.
 This section describes the Jakarta EE contracts that must be fulfilled by a Jakarta EE Product
 Provider implementing the full Jakarta EE platform. Jakarta EE profiles may
 include some or all of these facilities, as described in
-<<a3212, Profiles>>”.
+<<a3212, Profiles>>.
 
 ==== Jakarta EE APIs
 
@@ -803,7 +803,7 @@ This specification defines the mapping of
 application components to industry-standard network protocols. The
 mapping allows client access to the application components from systems
 that have not installed Jakarta EE product technology. See
-<<a2845, Interoperability>>,” for
+<<a2845, Interoperability>>, for
 details on the network protocol support required for interoperability.
 
 The Jakarta EE Product Provider is required to

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -149,15 +149,15 @@ annotations defined by the Common Annotations specification ( _Resource_,
 The following functionality is required to be
 supported in all Jakarta EE profiles:
 
-* JNDI “java:” naming context (see <<a607, JNDI Naming Context>>”)
+* JNDI “java:” naming context (see <<a607, JNDI Naming Context>>)
 * Jakarta Transactions
 
 === Optional Features for Jakarta EE Profiles
 
 All the technologies listed in
-<<a2136, Required APIs>>”, and
+<<a2136, Required APIs>>, and
 not designated as required in
-<<a3240, Requirements for All Jakarta EE Profiles>>”, are designated as optional for use in Jakarta EE
+<<a3240, Requirements for All Jakarta EE Profiles>>, are designated as optional for use in Jakarta EE
 profiles.
 
 **TODO** Since CORBA support was removed for Jakarta EE 9, do we just remove this paragraph?
@@ -166,9 +166,9 @@ The following functionality is designated as
 optional for use in Jakarta EE profiles:
 
 * RMI/IIOP interoperability requirements (see
-<<a2875, OMG Protocols (Proposed Optional)>>”)
+<<a2875, OMG Protocols (Proposed Optional)>>)
 * Support for _java:comp/ORB_ (see
-<<a1385, ORB References>>”)
+<<a1385, ORB References>>)
 
 [[a3252]]
 === Full Jakarta™ EE Product Requirements

--- a/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
@@ -5,7 +5,7 @@ The Jakarta™ EE Platform includes several technologies that are primarily
 intended to be used to extend the capabilities of the Jakarta EE containers.
 In addition, some Jakarta EE technologies include service provider interfaces
 along with their application programming interfaces. A Jakarta EE profile may
-include some or all of these facilities, as described in <<a3212, Profiles>>”.
+include some or all of these facilities, as described in <<a3212, Profiles>>.
 
 === Jakarta™ Connectors
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

EFSL had a syntax issue with a couple of URL references.  And, a quick scan of the specs found some extraneous quote marks with doc references, so I removed them.  