### PR TITLE
forgot enterprise web services from release plan

### DIFF
--- a/jakartaee9/JakartaEE9ReleasePlan.md
+++ b/jakartaee9/JakartaEE9ReleasePlan.md
@@ -99,6 +99,7 @@ List of existing specifications in Jakarta EE 9:
 *   Jakarta Connectors
 *   Jakarta Standard Tag Library
 *   Jakarta Enterprise Beans
+*   Jakarta Enterprise Web Services
 *   Jakarta Security
 *   Jakarta Server Faces
 *   Jakarta EE 9 Full Platform
@@ -210,6 +211,7 @@ The specifications included in Wave 5 are:
 *   Jakarta Connectors
 *   Jakarta Standard Tag Library
 *   Jakarta Enterprise Beans
+*   Jakarta Enterprise Web Services
 
 
 #### Wave 6


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Ed pointed out that we accidentally forgot to include Enterprise Web Services (JSR 109) in the Release Plan.  We do have an [Epic Issue for this effort](https://github.com/eclipse-ee4j/jax-ws-api/issues/98) and it's assigned to Wave 5.  But, it should still be listed in the Release Plan.  Thus, this required update. 