### PR TITLE
provide pointer to schedule from release plan

### DIFF
--- a/jakartaee9/JakartaEE9.md
+++ b/jakartaee9/JakartaEE9.md
@@ -56,8 +56,8 @@ Overall schedule (dates are ***tentative*** and ***subject to change***).  The w
 ### Jakarta EE 9 Project board
 
 Jakarta EE 9 will track its development progress with a [Github Project Board](https://github.com/orgs/eclipse-ee4j/projects/17).
-An individual Epic Issue was created for each Specification Project to track its progress.  
+An individual Epic Issue was created for each Specification Project to track its progress.
 For example, here's a link to the [Jakarta EE Platform Specification Version 9 Issue](https://github.com/eclipse-ee4j/jakartaee-platform/issues/133).
 
-The [Jakarta EE Release repo](https://github.com/eclipse-ee4j/jakartaee-release) will also be used for Issue tracking across the overall project.  
+The [Jakarta EE Release repo](https://github.com/eclipse-ee4j/jakartaee-release) will also be used for Issue tracking across the overall project.
 For example, the [Milestone/Release Candidate API artifacts](https://github.com/eclipse-ee4j/jakartaee-release/issues) are tracked in this repository.

--- a/jakartaee9/JakartaEE9ReleasePlan.md
+++ b/jakartaee9/JakartaEE9ReleasePlan.md
@@ -261,6 +261,8 @@ The project team believe this timeline is aggressive and these are **_early esti
 4. Full Profile and Web Profile First Release Candidate (May 4th)
 5. Full Profile and Web Profile Final Release Review Votes Start (June 12th)
 
+**Update:** These were the original ***proposed*** progress review dates at the time of the finalized Release Plan (Dec 2019).
+The overall schedule for Jakarta EE 9 will now be maintained on [this separate page](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9#jakarta-ee-9-schedule).
 
 ### Compatible Implementation          
 

--- a/jakartaee9/JakartaEE9ReleasePlanFAQ.md
+++ b/jakartaee9/JakartaEE9ReleasePlanFAQ.md
@@ -15,10 +15,11 @@ This FAQ should be used to complement the [Jakarta EE 9 Release Plan](https://ec
 **TCK**
 - [Keep the old `javax` signature files?](#keep-the-old-javax-signature-files)
 
-### Is adding @Deprecated allowed?
 
-Adding @Deprecated to the Java code is allowed where it is currently defined in the Javadoc (consistency).
-But, introducing newly @Deprecated classes or methods would require a separate Release Plan for that Project.
+### Is adding `@Deprecated` allowed?
+
+Adding `@Deprecated` to the Java code is allowed where it is currently defined in the Javadoc (consistency).
+But, introducing newly `@Deprecated` classes or methods would require a separate Release Plan for that Project.
 
 ### Is introducing Generics in the API signatures allowed?
 
@@ -26,19 +27,18 @@ No.
 Although there were simple cases identified where the introduction of Generics would be okay, it was decided to keep it simple and not allow the introduction of Generics in the Jakarta EE 9 APIs.
 Any proposed use of Generics would require a separate Release Plan for that Project.
 
-### Is adding @Repeatable allowed?
+### Is adding `@Repeatable` allowed?
 
-Adding @Repeatable to the Java code is allowed where it should it have been introduced in previous Java EE or Jakarta EE releases (consistency).
+Adding `@Repeatable` to the Java code is allowed where it should it have been introduced in previous Java EE or Jakarta EE releases (consistency).
 
 ### Should `javax` property names be renamed to `jakarta`?
 
 Yes, `javax.*` property names should be renamed to `jakarta.*` for all properties defined by Jakarta EE 9.
-Pruned Jakarta EE Projects will leave their property names in the `javax.*` namespace.
+Removed Jakarta EE Projects will leave their property names in the `javax.*` namespace (along with the APIs).
 
 ### Will the target namespace change for schemas?
 
-Yes, the proposed target namespace is `https://jakarta.ee/xml/ns/jakartaee/`.  
-This work is being tracked [via this bug](https://github.com/jakartaee/jakarta.ee/issues/592).
+Yes, the target namespace is [`https://jakarta.ee/xml/ns/jakartaee/`](https://jakarta.ee/xml/ns/jakartaee/#9).  
 
 ### Keep the old `javax` signature files?
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The main point of this PR is to provide a link from the approved Release Plan to the Jakarta EE 9 Schedule page. While doing that, I also removed some extra whitespace which was preventing proper formatting.  And, I added some tick marks (``) to highlight the use of annotations.