### PR TITLE
Make Java SE 8 the priority runtime for Jakarta EE 9

### DIFF
--- a/jakartaee9/JakartaEE9ReleasePlan.md
+++ b/jakartaee9/JakartaEE9ReleasePlan.md
@@ -57,7 +57,7 @@ Jakarta EE 9 WILL NOT impose any backward compatibility requirements for compati
 
 ### Java SE Version
 
-For inclusion in Jakarta EE 9, specification’s APIs MUST be compiled at the Java SE 8 source level.  However, compatible implementations of the Jakarta EE 9 Web Profile and Full Profile MUST certify compatibility on Java SE 11. Compatible Implementations MAY additionally certify and support Java SE 8.
+For inclusion in Jakarta EE 9, specification’s APIs MUST be compiled at the Java SE 8 source level.  Compatible Implementations of the Jakarta EE 9 Platform and Web Profile MUST certify compatibility on Java SE 8. Compatible Implementations MAY additionally certify and support Java SE 11.
 
 
 ### Individual Specification Versioning

--- a/jakartaee9/JakartaEE9ReleasePlan.md
+++ b/jakartaee9/JakartaEE9ReleasePlan.md
@@ -57,7 +57,7 @@ Jakarta EE 9 WILL NOT impose any backward compatibility requirements for compati
 
 ### Java SE Version
 
-For inclusion in Jakarta EE 9, specification’s APIs MUST be compiled at the Java SE 8 source level.  Compatible Implementations of the Jakarta EE 9 Platform and Web Profile MUST certify compatibility on Java SE 8. Compatible Implementations MAY additionally certify and support Java SE 11.
+For inclusion in Jakarta EE 9, specification’s APIs MUST be compiled at the Java SE 8 source level.  Compatible Implementations of the Jakarta EE 9 Platform and Web Profile MUST certify compatibility on Java SE 8. Compatible Implementations MAY additionally certify and support later versions of the Java SE runtime.
 
 
 ### Individual Specification Versioning


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Slight update to the Jakarta EE 9 Release Plan to prioritize Java SE 8 over Java SE 11.  This was discussed with the Platform Dev and Spec Project Lead mailing lists, as well getting endorsed by the Steering Committee.