### PR TITLE
Add jakarta- prefix to the names of the generated specifications

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -1,8 +1,8 @@
 Jakarta EE Platform Specification
 =================================
 
-This project generates the Jakarta EE Platform Specification
-the Jakarta EE Web Profile Specification, and the Managed Beans
+This project generates the Jakarta EE Platform Specification, 
+the Jakarta EE Web Profile Specification, and the Jakarta Managed Beans
 Specification.
 
 Building
@@ -18,11 +18,11 @@ Run the full build:
 `mvn install`
 
 Locate the html files:
-- `target/generated-docs/platform-spec-<version>.html`
-- `target/generated-docs/webprofile-spec-<version>.html`
-- `target/generated-docs/managedbeans-spec-<version>.html`
+- `target/generated-docs/jakarta-platform-spec-<version>.html`
+- `target/generated-docs/jakarta-webprofile-spec-<version>.html`
+- `target/generated-docs/jakarta-managedbeans-spec-<version>.html`
 
 Locate the PDF files:
-- `target/generated-docs/platform-spec-<version>.pdf`
-- `target/generated-docs/webprofile-spec-<version>.pdf`
-- `target/generated-docs/managedbeans-spec-<version>.pdf`
+- `target/generated-docs/jakarta-platform-spec-<version>.pdf`
+- `target/generated-docs/jakarta-webprofile-spec-<version>.pdf`
+- `target/generated-docs/jakarta-managedbeans-spec-<version>.pdf`

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-specs</artifactId>
     <packaging>pom</packaging>
-    <version>9-SNAPSHOT</version>
+    <version>9</version>
     <name>Jakarta EE Platform Specifications</name>
 
     <properties>
@@ -41,7 +41,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <managedbean.version>2.0-SNAPSHOT</managedbean.version>  <!-- override <version> for Managed Beans spec-->
+        <managedbean.version>2.0</managedbean.version>  <!-- override <version> for Managed Beans spec-->
     </properties>
 
     <scm>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,10 +25,10 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.platform</groupId>
-    <artifactId>platform-spec</artifactId>
+    <artifactId>platform-specs</artifactId>
     <packaging>pom</packaging>
     <version>9-SNAPSHOT</version>
-    <name>Jakarta EE Platform Specification</name>
+    <name>Jakarta EE Platform Specifications</name>
 
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
@@ -117,7 +117,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <sourceDocumentName>platform-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/platform-spec-${project.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-platform-spec-${project.version}.html</outputFile>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
@@ -133,7 +133,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <sourceDocumentName>platform-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/platform-spec-${project.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-platform-spec-${project.version}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
@@ -153,7 +153,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <sourceDocumentName>webprofile-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/webprofile-spec-${project.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-webprofile-spec-${project.version}.html</outputFile>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
@@ -169,7 +169,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <sourceDocumentName>webprofile-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/webprofile-spec-${project.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-webprofile-spec-${project.version}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
@@ -189,7 +189,7 @@
                         <configuration>
                             <backend>html5</backend>
                             <sourceDocumentName>managedbeans-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/managedbeans-spec-${managedbean.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-managedbeans-spec-${managedbean.version}.html</outputFile>
                             <attributes>
                                 <toc>left</toc>
                                 <revnumber>${managedbean.version}</revnumber>
@@ -206,7 +206,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <sourceDocumentName>managedbeans-spec.adoc</sourceDocumentName>
-                            <outputFile>${project.build.directory}/generated-docs/managedbeans-spec-${managedbean.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/jakarta-managedbeans-spec-${managedbean.version}.pdf</outputFile>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Per a suggested change on the Spec Committee call, I am updating the generated specification names to include the `jakarta-` prefix.  Updated the Copyright date to 2020.

Updated the README to show the new names appropriately.

And, a couple of updates to wording to show that we generate multiple specifications with this one repository.