### PR TITLE
Remove the TODO for the JakartaEEArchitecture diagram

### DIFF
--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -35,8 +35,6 @@ As indicated, the APIs of the Java™
 Platform, Standard Edition (Java SE), are supported by Java SE runtime
 environments for each type of application component.
 
-*TODO:* This diagram needs adjustments for Jakarta EE 9...
-
 [[a45]]
 .Jakarta EE Architecture Diagram
 image::JakartaEEarchitecture.svg[]


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The Architecture diagram was updated via PR #219.  We can remove the TODO.