### PR TITLE
Update section on DD support for past schemas

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -1278,10 +1278,9 @@ is in general case sensitive. This means, for example, that
 _<role-name>Manager</role-name>_ is a different role than
 _<role-name>manager</role-name>_ .
 
-All valid Jakarta EE application deployment
-descriptors must conform to the XML Schema definition, or the DTD or
-schema definition from a previous version of this specification. (See
-<<a3447, Previous Version Deployment Descriptors>>.) The deployment descriptor must be named
+All valid Jakarta EE application deployment descriptors must conform to the XML 
+Schema definitions as defined by <<a3447, Previous Version Deployment Descriptors>>. 
+The deployment descriptor must be named
 _META-INF/application.xml_ in the _.ear_ file. Note that this name is
 case-sensitive. The XML Schema located at
 _https://jakarta.ee/xml/ns/jakartaee/application_9.xsd_ defines the XML

--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -1278,8 +1278,9 @@ is in general case sensitive. This means, for example, that
 _<role-name>Manager</role-name>_ is a different role than
 _<role-name>manager</role-name>_ .
 
-All valid Jakarta EE application deployment descriptors must conform to the XML 
-Schema definitions as defined by <<a3447, Previous Version Deployment Descriptors>>. 
+All valid Jakarta EE application deployment
+descriptors must conform to the XML Schema definitions
+as defined by <<a3447, Previous Version Deployment Descriptors>>. 
 The deployment descriptor must be named
 _META-INF/application.xml_ in the _.ear_ file. Note that this name is
 case-sensitive. The XML Schema located at


### PR DESCRIPTION
Minor update to remove the reference to old DTD files and point at the Appendix for more complete information.