### PR TITLE
revert PR 189 (don't touch the EFSL content)

### DIFF
--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -53,7 +53,7 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018, 2020 Eclipse Foundation. This software or
+"Copyright (c) [$date-of-document] Eclipse Foundation. This software or
 document includes material copied from or derived from [title and URI
 of the Eclipse Foundation specification document]."
 

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -15,7 +15,7 @@ Release: {revdate}
 ....
 == Copyright
 
-Copyright (c) 2018,2020 Eclipse Foundation.
+Copyright (c) 2018, 2020 Eclipse Foundation.
 
 == Eclipse Foundation Specification License
 
@@ -34,7 +34,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -53,9 +53,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018,2020 Eclipse Foundation. This software or
-document includes material copied from or derived from 
-Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/[]."
+"Copyright (c) 2018, 2020 Eclipse Foundation. This software or
+document includes material copied from or derived from [title and URI
+of the Eclipse Foundation specification document]."
 
 === Disclaimers
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

It has been determined that no changes to the EFSL text are warranted.  Based on some invalid information, I had created Issues for all of the Jakarta EE specifications to update the EFSL text used by Specifications and APIs.  This was not correct.  If the changes were already done, you can leave them as-is for Jakarta EE 9 and correct them in the next release.  I have chosen to correct them in Jakarta EE 9 since we are not final yet.