### PR TITLE
Complete section on RMI-IIOP and add some history

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -390,9 +390,6 @@ The following Jakarta EE Technologies were removed from the Jakarta EE Platform.
 
 |Distributed Interoperability (EJB 3.2 Core Specification, Chapter 10)
 |Removed in Jakarta EE 9
-
-|CORBA, Java IDL, RMI-IIOP
-|Removed in Jakarta EE 9
 |===
 
 [[a2339]]

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -1001,7 +1001,7 @@ application component types can be clients of RMI objects.
 
 The RMI-IIOP subsystem is composed of APIs that allow for the
 use of RMI-style programming that is independent of the underlying
-protocol.  Implementations these APIs may support the Java SE native RMI
+protocol.  Implementations of these APIs may support the Java SE native RMI
 protocol (JRMP), the CORBA IIOP protocol or any custom protocol that is
 compatible with the RMI programming restrictions (see the RMI-IIOP spec
 for details).
@@ -1010,7 +1010,7 @@ NOTE: The requirements in this section only apply to Jakarta EE products that
 include an Enterprise Beans container with support for remote interfaces.
 
 Jakarta EE applications use the RMI-IIOP APIs when accessing
-remote Enterprise JavaBeans components, as described in the Jakarta Enterprise
+remote Enterprise Beans components, as described in the Jakarta Enterprise
 Beans 4.0 specification.  This allows Enterprise Beans and their clients to be
 protocol independent and portable to Jakarta EE implementations that may use
 CORBA/IIOP, RMI, or any other custom protocol.  However, there is currently no
@@ -1024,7 +1024,7 @@ programming restrictions necessary to allow application portability.  Requiremen
 for implementations to use CORBA/IIOP itself were added to J2EE 1.3 and EJB 2.0 and
 expanded the term RMI-IIOP beyond application portability and into distributed
 interoperability. These distributed interoperability requirements
-were marked Proposed Optional in Java EE 1.8 .  As of Jakarta EE 9 and Enterprise
+were marked Proposed Optional in Java EE 8 .  As of Jakarta EE 9 and Enterprise
 Beans 4.0 distributed interoperability requirements are fully removed and the term
 RMI-IIOP reverts back to a term that guarantees only application portability, not
 distributed interoperability.  Remaining use of the narrow method of

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -1000,91 +1000,48 @@ _https://jakarta.ee/specifications/xml-web-services/_ .
 
 ===== RMI-JRMP
 
-*TODO Note:* What to do with this section? Leave as-is, mark Optional, remove?
-
 JRMP is the Java technology-specific Remote
 Method Invocation (RMI) protocol. The Jakarta EE security restrictions
 typically prevent all application component types except application
 clients from creating and exporting an RMI object, but all Jakarta EE
 application component types can be clients of RMI objects.
 
-===== RMI-IIOP (Proposed Optional)
+===== RMI-IIOP
 
-*TODO Note:* Since distributed interop is being removed from the EJB spec, do we remove
-this section completely?
+The RMI-IIOP subsystem is composed of APIs that allow for the
+use of RMI-style programming that is independent of the underlying
+protocol.  Implementations these APIs may support the Java SE native RMI
+protocol (JRMP), the CORBA IIOP protocol or any custom protocol that is
+compatible with the RMI programming restrictions (see the RMI-IIOP spec
+for details).
 
-The requirements in this section only apply
-to Jakarta EE products that include an Enterprise Beans container and support
-interoperability using RMI-IIOP.
+NOTE: The requirements in this section only apply to Jakarta EE products that
+include an Enterprise Beans container with support for remote interfaces.
 
-RMI-IIOP allows objects defined using RMI
-style interfaces to be accessed using the IIOP protocol. It must be
-possible to make any remote _enterprise bean accessible via_ RMI-IIOP.
-Some Jakarta  EE products will simply make all remote enterprise beans
-always (and only) accessible via RMI-IIOP; other products might control
-this via an administrative or deployment action. These and other
-approaches are allowed, provided that any remote enterprise bean (or by
-extension, all remote enterprise beans) can be made accessible using
-RMI-IIOP.
+Jakarta EE applications are required to use the RMI-IIOP APIs (specifically the
+narrow method of javax.rmi.PortableRemoteObject) when accessing
+remote Enterprise JavaBeans components, as described in the Jakarta Enterprise
+Beans 4.0 specification.  This allows Enterprise Beans and their clients to be
+protocol independent and portable to Jakarta EE implementations that may use
+CORBA or RMI as their underlying protocol.  However, there is currently no
+requirement that Enterprise Beans be accessible using the IIOP protocol itself
+or that Jakarta EE implementations support any form of distributed interoperability
+with other Jakarta EE implementations.
 
-Components accessing remote _enterprise
-beans_ may need to use the _narrow_ method of the
-_javax.rmi.PortableRemoteObject_ class, under circumstances described in
-the Jakarta Enterprise Beans specification. Because remote enterprise beans may be deployed
-using other RMI protocols, portable applications must not depend on the
-characteristics of RMI-IIOP objects (for example, the use of the _Stub_
-and _Tie_ base classes) beyond what is specified in the Jakarta Enterprise Beans
-specification.
+The use of the term RMI-IIOP has existed since J2EE 1.2 and EJB 1.1, predates
+any requirements to support CORBA itself and was used to detail application
+programming restrictions necessary to allow application portability.  Requirements
+for implementations to use CORBA IIOP itself were added to J2EE 1.3 and EJB 2.0 and
+expanded the term RMI-IIOP beyond application portability and into distributed
+interoperability. These distributed interoperability requirements
+were marked Proposed Optional in Java EE 1.8 .  As of Jakarta EE 9 and Enterprise
+Beans 4.0 distributed interoperability requirements are fully removed and the term
+RMI-IIOP reverts back to a term that guarantees only application portability, not
+distributed interoperability.
 
-The Jakarta EE security restrictions typically
-prevent all application component types, except application clients,
-from creating and exporting an RMI-IIOP object. All Jakarta EE application
-component types can be clients of RMI-IIOP objects. Jakarta EE applications
-should also use JNDI to lookup non-Enterprise Beans RMI-IIOP objects. The JNDI names
-used for such non-Enterprise Beans RMI-IIOP objects should be configured at
-deployment time using the standard environment entries mechanism (see
-<<a607, JNDI Naming Context>>).
-The application should fetch a name from JNDI using an environment
-entry, and use the name to lookup the RMI-IIOP object. Typically such
-names will be configured to be names in the COSNaming name service.
-
-This specification does not provide a
-portable way for applications to bind objects to names in a name
-service. Some products may support use of JNDI and COSNaming for binding
-objects, but this is not required. Portable Jakarta EE application clients
-can create non-Enterprise Beans RMI-IIOP server objects for use as callback objects,
-or to pass in calls to other RMI-IIOP objects.
-
-Note that while RMI-IIOP doesn’t specify how
-to propagate the current security context or transaction context, the
-Jakarta Enterprise Beans interoperability specification does define such context propagation.
-This specification only requires that the propagation of context
-information as defined in the Jakarta Enterprise Beans specification be supported in the use
-of RMI-IIOP to access enterprise beans. The propagation of context
-information is not required in the uses of RMI-IIOP to access objects
-other than enterprise beans.
-
-The RMI-IIOP specification describes how
-portable Stub and _Tie_ classes can be created. To be portable to all
-implementations that use a CORBA Portable Object Adapter (POA), the
-_Tie_ classes must extend the _org.omg.PortableServer.Servant_ class.
-This is typically done by using the _-poa_ option to the _rmic_ command.
-A Jakarta EE product must provide support for these portable _Stub_ and
-_Tie_ classes, typically using the required CORBA POA. However, for
-portability to systems that do not use a POA to implement RMI-IIOP,
-applications should not depend on the fact that the _Tie_ extends the
-_Servant_ class. A Jakarta EE application that defines or uses RMI-IIOP
-objects other than enterprise beans must include such portable _Stub_
-and _Tie_ classes in the application package. _Stub_ and _Tie_ objects
-for enterprise beans, however, must not be included with the
-application: they will be generated, if needed, by the Jakarta EE product
-at deployment time or at run time.
-
-RMI-IIOP is defined by chapters 5, 6, 13, 15,
-and section 10.6.2 of the CORBA 2.3.1 specification, available at
-_http://www.omg.org/cgi-bin/doc?formal/99-10-07_ , and by the Java™
-Language To IDL Mapping Specification, available at
-_http://www.omg.org/cgi-bin/doc?ptc/2000-01-06_ .
+Jakarta EE implementations may use CORBA IIOP as their underlying protocol, however,
+such support is implementation-specific and no longer a guarantee of the Jakarta
+EE platform.
 
 ===== JNDI
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -89,12 +89,6 @@ This is a stronger statement than making a technology "optional", since a "remov
 technology will no longer be maintained for future versions of the Platform.
 <<a2333, Removed Jakarta Technologies>> documents these removed technologies.
 
-*Table TODO* There doesn't seem to be any rhyme or reason to the ordering of the contents
-of this table.  Maybe it was done in the order of the specs getting added to the platform?
-Maybe we should just alphabetize the technologies? Reminder -- If the rows in this table
-get re-organized, then the Requirements sections at the end of this API section also need to
-be similarly re-organized.
-
 [[a2159]]
 [cols=5, options=header]
 .Jakarta EE Technologies
@@ -1018,12 +1012,11 @@ for details).
 NOTE: The requirements in this section only apply to Jakarta EE products that
 include an Enterprise Beans container with support for remote interfaces.
 
-Jakarta EE applications are required to use the RMI-IIOP APIs (specifically the
-narrow method of javax.rmi.PortableRemoteObject) when accessing
+Jakarta EE applications use the RMI-IIOP APIs when accessing
 remote Enterprise JavaBeans components, as described in the Jakarta Enterprise
 Beans 4.0 specification.  This allows Enterprise Beans and their clients to be
 protocol independent and portable to Jakarta EE implementations that may use
-CORBA or RMI as their underlying protocol.  However, there is currently no
+CORBA/IIOP, RMI, or any other custom protocol.  However, there is currently no
 requirement that Enterprise Beans be accessible using the IIOP protocol itself
 or that Jakarta EE implementations support any form of distributed interoperability
 with other Jakarta EE implementations.
@@ -1031,15 +1024,16 @@ with other Jakarta EE implementations.
 The use of the term RMI-IIOP has existed since J2EE 1.2 and EJB 1.1, predates
 any requirements to support CORBA itself and was used to detail application
 programming restrictions necessary to allow application portability.  Requirements
-for implementations to use CORBA IIOP itself were added to J2EE 1.3 and EJB 2.0 and
+for implementations to use CORBA/IIOP itself were added to J2EE 1.3 and EJB 2.0 and
 expanded the term RMI-IIOP beyond application portability and into distributed
 interoperability. These distributed interoperability requirements
 were marked Proposed Optional in Java EE 1.8 .  As of Jakarta EE 9 and Enterprise
 Beans 4.0 distributed interoperability requirements are fully removed and the term
 RMI-IIOP reverts back to a term that guarantees only application portability, not
-distributed interoperability.
+distributed interoperability.  Remaining use of the narrow method of
+`javax.rmi.PortableRemoteObject` is slated for removal in a future release.
 
-Jakarta EE implementations may use CORBA IIOP as their underlying protocol, however,
+Jakarta EE implementations may use CORBA/IIOP as their underlying protocol, however,
 such support is implementation-specific and no longer a guarantee of the Jakarta
 EE platform.
 
@@ -1185,37 +1179,16 @@ applications.
 
 === Enterprise Beans 4.0 Requirements
 
-*TODO Note:*  This section still needs some work due to the revamping of the EJB 4.0
-spec for Jakarta EE 9...
-
 This specification requires that a  Jakarta EE
 product provide support for _enterprise beans_ as specified in the Jakarta Enterprise
 Beans specification. The Jakarta Enterprise Beans specification is available at
 _https://jakarta.ee/specifications/enterprise-beans_ .
 
-This specification does not impose any
-additional requirements at this time. Note that the Jakarta Enterprise Beans
-specification includes the specification of the Jakarta Enterprise Beans
-interoperability protocol based on RMI-IIOP. Support for the Jakarta Enterprise Beans
-interoperability protocol is Proposed Optional in Jakarta EE 8. All containers that
-support Jakarta Enterprise Beans clients must be capable of using the
-Jakarta Enterprise Beans interoperability protocol to invoke enterprise
-beans. All Jakarta Enterprise Beans containers must support the invocation of enterprise
-beans using the Jakarta Enterprise Beans interoperability protocol. A Jakarta EE
-product may also support other protocols for the invocation of enterprise beans.
-
-A Jakarta EE product may support multiple object
-systems (for example, RMI-IIOP and RMI-JRMP). It may not always be
-possible to pass object references from one object system to objects in
-another object system. However, when an enterprise bean is using the
-RMI-IIOP protocol, it must be possible to pass object references for
-RMI-IIOP or Java IDL objects as arguments to methods on such an
-enterprise bean, and to return such object references as return values
-of a method on such an enterprise bean. In addition, it must be possible
-to pass a reference to an RMI-IIOP-based enterprise bean’s Home or
-Remote interface to a method on an RMI-IIOP or Java IDL object, or to
-return such an enterprise bean object reference as a return value from
-such an RMI-IIOP or Java IDL object.
+A Jakarta EE product may support multiple object systems (for example,
+RMI-IIOP, RMI-JRMP, gRPC, protobuf, Thrift).  There is no explicit
+requirement that a Jakarta EE product support any specific protocol,
+such as CORBA/IIOP, or provide distributed interoperability between
+products.
 
 In a Jakarta EE product that includes both an
 enterprise beans container and a web container, both containers are required to


### PR DESCRIPTION
This is perhaps a bit redundant, but given the history on this feature and reasonable confusion I think there's some benefit to having the requirements restated a couple times.  The line between portability and interoperability needs to be 100% clear.  RMI-IIOP is no longer relevant for interoperability, but still very relevant to portability.

RMI-IIOP programming restrictions remain intact and allow Jakarta EE implementations freedom to chose CORBA or any other protocol.

A concrete example is a Jakarta EE implementation could use HTTP and application/json as their underlying protocol, however, they would need to support RMI-IIOP semantics:  they must support `java.io.Serializable`, `java.io.Externalizable` and call all associated callbacks such as  `readObject` and `replaceObject` detailed by those interfaces; they must not serialize/deserialize classes that do not implement Serializable or Externalizable;  they must retain the references in the serialized object graph entirely upon deserialization.

Maintaining references within an object graph is something text protocols typically cannot do and is likely to be a source of portability issues should more protocols enter our ecosystem.  As an example early SOAP implementations used SOAP Encoded semantics and could handle complex reference situations such as the same object being in a map 4 times and deserialized cleanly as one map containing four references to the same object.  Later SOAP implementations favored "doc literal wrapped", which would handle the same situation by completely serializing the object four times resulting in a deserialized map that had four copies of the object resulting in a deserialized object graph that is fundamentally different from the serialized object graph.  This later behavior would not be OK from the eyes of RMI or IIOP (referred to as RMI-IIOP for shorthand).

We currently do not have significant tests for these guarantees.  These tests are not there because they were part of the RMI-IIOP interoperability tests, which are removed as they are unfortunately also CORBA specific.  We would need a new suite that is exclusively focused on portability, not interoperability.  Should we find ourselves in a situation where new protocols find their way into the next generation of Jakarta EE implementations and people notice portability in serialization/deserialization semantics (a deserialized object graph is not quite the same when porting from one server to another), we will need to expand our tests.


