### PR TITLE
Update Revision Histories for final docs

### DIFF
--- a/specification/src/main/asciidoc/managedbeans/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/managedbeans/RevisionHistory.adoc
@@ -1,10 +1,11 @@
 [appendix]
 == Revision History
+=== Changes in Final Release
+==== Editorial Changes
+* Changed the name of the generated Specifications to match the short name for the component (managed-beans).
 
 === Changes in Milestone Release Draft
-
 ==== Editorial Changes
-
 * Initial contribution of the Managed Beans Specification source.
 * Changed most instances of "Java EE" to "Jakarta EE", except where the previous technology was clearly the target.
 * Modified references to Oracle(TM)-related items per the https://jakarta.ee/legal/acronym_guidelines/[documented guidelines].

--- a/specification/src/main/asciidoc/platform/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/platform/RevisionHistory.adoc
@@ -1,17 +1,21 @@
 [appendix]
 [[revisionHistory]]
 == Revision History
+=== Changes in Final Release
+==== Editorial Changes
+* Removed the requirement for implementations to run on Java SE 11.
+* Updated the figures to svg format to make for easier updating.
+* Documented the impact of the removal of Distributed Interop from the Enterprise Beans Specification.
+* *TODO* Created a new section of Backwards Compatibility.
+* *TODO* Documented the Java Module conventions for Jakarta EE 9.
 
 === Changes in Milestone Release Draft
-
 ==== Editorial Changes
-
 * Updates per Jakarta EE 9 Release Plan, https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan.
 * Changed package name of Jakarta EE 9 classes to `jakarta` namespace where appropriate.
 * Updated the requirement on Java SE 8 for the APIs and Java SE 11 for the implementations.
 * Defined Proposed Optional, Optional, and Removed lifecycle states for Specifications and Features.
 Applied these definitions through out document.
-* **TODO** Properly document the removal of OMG, CORBA, and IIOP from Jakarta EE 9.
 * Re-organized the <<a3447, "Previous Version Deployment Descriptors">> section to differentiate between the versions
 of J2EE, Java EE, and Jakarta EE.
 * Updated <<relateddocs, “Related Documents">> appendix for the updated Jakarta EE 9 specifications.

--- a/specification/src/main/asciidoc/webprofile/Introduction.adoc
+++ b/specification/src/main/asciidoc/webprofile/Introduction.adoc
@@ -94,7 +94,7 @@ For the first one, the Jakarta EE Platform
 specification mandates support for the “ _java:_ ” naming context in all
 profiles. Consequently, Web Profile products must support it. For a
 similar reason, all Web Profile 9 APIs must support the Java(TM) Platform, Standard Edition 8 API,
-and all Web Profile 9 products must run on Java(TM) Platform, Standard Edition 11 runtime.
+and all Web Profile 9 products must run on Java(TM) Platform, Standard Edition 8 runtime.
 
 In the second category one can point out the
 requirement to support Jakarta EE web application modules ( _.war_ files)

--- a/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
@@ -10,8 +10,6 @@ _Jakarta™ EE Platform Specification Version 9_. Available at: _https://jakarta
 
 _Java™ Platform, Standard Edition, v8 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/javase/8/docs/_
 
-_Java™ Platform, Standard Edition, v11 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/en/java/javase/11/_
-
 _Jakarta™ Enterprise Beans Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/enterprise-beans/4.0_
 
 _Jakarta™ Server Pages Specification, Version 3.0_. Available at: _https://jakarta.ee/specifications/pages/3.0_

--- a/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
@@ -1,10 +1,12 @@
 [appendix]
+
 == Revision History
+=== Changes in Final Release
+==== Editorial Changes
+* Removed the requirement for implementations to run on Java SE 11.
 
 === Changes in Milestone Release Draft
-
 ==== Editorial Changes
-
 * Updated all referenced Jakarta EE component versions per the Jakarta EE 9 release plan.
 * Updated the requirement on Java SE 8 for the APIs and Java SE 11 for the implementations.
 * Updated <<relateddocs, “Related Documents">> for the updated Specifications in Jakarta EE 9.


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Main goal of this PR is to provide the "final" revision history section for the three specs (platform, web profile, and managed beans).  One of the main items was to remove the requirement on the Implementations to run on Java SE 11.  A few other editorial changes were done as well. 