### PR TITLE
remove TODO from Profiles section

### DIFF
--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -163,8 +163,8 @@ profiles.
 The following functionality is designated as
 optional for use in Jakarta EE profiles:
 
-* RMI/IIOP interoperability requirements (see
-<<a2875, OMG Protocols (Proposed Optional)>>)
+* CORBA requirements (see
+<<a2875, OMG Protocols>>)
 * Support for _java:comp/ORB_ (see
 <<a1385, ORB References>>)
 

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -160,8 +160,6 @@ not designated as required in
 <<a3240, Requirements for All Jakarta EE Profiles>>, are designated as optional for use in Jakarta EE
 profiles.
 
-**TODO** Since CORBA support was removed for Jakarta EE 9, do we just remove this paragraph?
-
 The following functionality is designated as
 optional for use in Jakarta EE profiles:
 
@@ -218,8 +216,6 @@ associated Jakarta Enterprise Beans QL, which have been made optional)
 * Jakarta Interceptors 2.0
 * Jakarta Contexts and Dependency Injection 3.0
 * Jakarta Dependency Injection 2.0
-
-
 
 The following technologies are optional:
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Since CORBA and IIOP are still Optional for Jakarta EE 9, this TODO can be removed.