### PR TITLE
Clarify "OMG Protocols" section was not optional previously

### DIFF
--- a/specification/src/main/asciidoc/platform/Interoperability.adoc
+++ b/specification/src/main/asciidoc/platform/Interoperability.adoc
@@ -105,7 +105,7 @@ been standardized by IETF under RFC 6455.
 [[a2875]]
 ==== OMG Protocols (optional)
 
-Support for the Object Management Group (OMG) based protocols continues to be optional for Jakarta EE 9.
+Support for the Object Management Group (OMG) based protocols is optional for Jakarta EE 9.
 
 ==== Java Technology Protocols
 


### PR DESCRIPTION
Replaced "continues to be optional" with "is optional."

It's understandable that its prior status as "Proposed Optional" can be confused with "Optional", but definitely interoperability was a requirement for a full platform implementation.  There were conversations about making it optional, but there were strong disagreements and we never got consensus.

Here's the argument and a great quote from Bill (who was pro-optional):

 - https://download.oracle.com/javaee-archive/javaee-spec.java.net/users/2015/10/1732.html

> If CORBA support is made Proposed Optional in Java EE 8 in 2017, it would be made Optional in Java EE 9 in approximately 2022 ....