### PR TITLE
Add Java Module naming guidelines

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -71,19 +71,20 @@ The specifications for the Java SE APIs are
 available at _http://docs.oracle.com/javase/8/docs/_ .
 
 ===== Java Module Names
-Java(TM) SE 9 introduced the concept of the Java Platform Module System (JPMS).
-Since Jakarta EE 9 is initially supporting Java SE 8, there is no requirement to define a module naming convention for the Jakarta EE 9 features.
-But, since Java SE 8 was updated to allow for the naming of modules in support of the future versions of Java, some Jakarta EE 9 features have already defined their corresponding module names.
-The following conventions are strongly suggested by the Platform project:
+Java(TM) SE 9 introduced the concept of a modularity system, known as the Java Platform Module System (JPMS).
+Defined modules need a _name_ to allow for references by other modules.
+Jakarta EE 9 is not defining a module naming convention since Jakarta EE 9 is only supporting Java SE 8.
+Some Java EE(TM) 8 and Jakarta EE features had already defined their corresponding module names.
+Due to these previous module naming efforts, the following guidelines are strongly suggested for Jakarta EE 9:
 
-* If an Automatic Module Name (MANIFEST) already exists, update it to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
+* If an Automatic Module Name (MANIFEST) already exists, update the name to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
 Do not create _new_ Automatic Module Names for Jakarta EE 9.  
-* If a module-info.class already exists, update it to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
+* If a module-info.class already exists, update the name to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
 Do not create _new_ module-info.class files for Jakarta EE 9. 
-* If neither Automatic Module Names or module-info.class exists, then leave it as-is.
+* If neither Automatic Module Names or module-info.class exists, then leave as-is.
 
-This approach defines guidelines for getting to a consistent state with the least amount of disruption.
-No matter what module names are defined in Jakarta EE 9, the module names may need to be updated once specific module name requirements are established in a future release.
+These guidelines allow existing module names to get to a consistent state with the least amount of disruption.
+Any existing module names may need to be updated once specific module name requirements are established in a future release.
 
 [[a2161]]
 ==== Required Jakarta Technologies

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -70,6 +70,21 @@ these technologies, as described in the following section.
 The specifications for the Java SE APIs are
 available at _http://docs.oracle.com/javase/8/docs/_ .
 
+===== Java Module Names
+Java(TM) SE 9 introduced the concept of the Java Platform Module System (JPMS).
+Since Jakarta EE 9 is initially supporting Java SE 8, there is no requirement to define a module naming convention for the Jakarta EE 9 features.
+But, since Java SE 8 was updated to allow for the naming of modules in support of the future versions of Java, some Jakarta EE 9 features have already defined their corresponding module names.
+The following conventions are strongly suggested by the Platform project:
+
+* If an Automatic Module Name (MANIFEST) already exists, update it to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
+Do not create _new_ Automatic Module Names for Jakarta EE 9.  
+* If a module-info.class already exists, update it to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
+Do not create _new_ module-info.class files for Jakarta EE 9. 
+* If neither Automatic Module Names or module-info.class exists, then leave it as-is.
+
+This approach defines guidelines for getting to a consistent state with the least amount of disruption.
+No matter what module names are defined in Jakarta EE 9, the module names may need to be updated once specific module name requirements are established in a future release.
+
 [[a2161]]
 ==== Required Jakarta Technologies
 

--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -10,6 +10,8 @@ _Jakarta™ EE Web Profile Version 9_. Available at: _https://jakarta.ee/specifi
 
 _Java™ Platform, Standard Edition, v8 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/javase/8/docs/_
 
+_Java™ Platform, Standard Edition, v9 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/javase/9/_
+
 _Java™ Platform, Standard Edition, v11 API Specification (Java SE specification)_. Available at: _https://docs.oracle.com/en/java/javase/11/_
 
 _Jakarta™ Enterprise Beans Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/enterprise-beans/4.0_


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Adding a short section on our defined Module Naming guidelines that were decided on the Platform call and mailing list.  [Option F in this google doc](https://docs.google.com/document/d/1LAAHKPJyREky9fEKv0xFd9IRDgXB58It53ryfyrNPtg/edit#) was the source for this section update.

I also updated our doc reference appendix to include a link to the Java SE 9 documentation.