### PR TITLE
change version to 9.1-SNAPSHOT

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-specs</artifactId>
     <packaging>pom</packaging>
-    <version>9</version>
+    <version>9.1-SNAPSHOT</version>
     <name>Jakarta EE Platform Specifications</name>
 
     <properties>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Since there is no automated build mechanism for the Platform project yet (reference issue #113), we have to manually update the version to "9.1-SNAPSHOT".  I have already created the [Release](https://github.com/eclipse-ee4j/jakartaee-platform/releases/tag/v9) and [Tag](https://github.com/eclipse-ee4j/jakartaee-platform/tree/v9) for Jakarta EE 9.  We are in the practice of only creating a Branch if and when it's necessary (just like we did the with the [Jakarta EE 8 release](https://github.com/eclipse-ee4j/jakartaee-platform/releases/tag/v8)).