### PR TITLE
[Issue 287] Clarify language regarding support for Java SE versions o…

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -583,7 +583,7 @@ referenced by the rar files themselves (as specified in
 <<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
 <<a2159, Jakarta EE Technologies>> for the web container.
-* All Java SE 8 API classes.
+* All required <<a3537, Java SE API classes>>.
 
 
 
@@ -661,7 +661,7 @@ referenced by the rar files themselves (as specified in
 <<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
 <<a2159, Jakarta EE Technologies>> for the Jakarta Enterprise Beans container.
-* All Java SE 8 API classes.
+* All required <<a3537, Java SE API classes>>.
 
 
 
@@ -724,7 +724,7 @@ specified by or referenced by the containing ear file (as specified in
 <<a2945, Library Support>>).
 * The Jakarta EE API classes specified in
 <<a2159, Jakarta EE Technologies>> for the application client container.
-* All Java SE 8 API classes.
+* All required <<a3537, Java SE API classes>>.
 
 
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -44,16 +44,16 @@ one of the enterprise technologies listed in this specification.
 
 The Java SE platform includes the following enterprise technologies:
 
-* Java IDL footnote:javaremoval[Removed from Java SE 11. See <<a2161, Required Jakarta Technologies>>.]
+* Java IDL footnote:[Removed from Java SE 11. Support for Java IDL is optional (see <<a3539, Java IDL (Optional)>>.) Product vendors that wish to support Java IDL on a Java SE version that does not provide the Java IDL APIs must otherwise provide those APIs to application components.]
 * JDBC
 * RMI-JRMP
-* RMI-IIOP footnote:javaremoval[]
+* RMI-IIOP footnote:[Removed from Java SE 11. Support for RMI-IIOP is optional (see <<a3538, RMI-IIOP (Optional)>>.) Product vendors that wish to support RMI-IIOP on a Java SE version that does not provide the RMI-IIOP APIs must otherwise provide those APIs to application components. Product vendors that support the optional Enterprise Beans 2.x API group must ensure that the javax.rmi.PortableRemoteObject class is available to application components.]
 * JNDI
 * JAXP
 * StAX
 * JAAS
 * JMX
-* JAX-WS footnote:javaremoval[]
+* JAX-WS footnote:javaremoval[Removed from Java SE 11. See <<a2161, Required Jakarta Technologies>>.]
 * JAXB footnote:javaremoval[]
 * JAF footnote:javaremoval[]
 * SAAJ footnote:javaremoval[]

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -47,7 +47,8 @@ The Java SE platform includes the following enterprise technologies:
 * Java IDL footnote:[Removed from Java SE 11. Support for Java IDL is optional (see <<a3539, Java IDL (Optional)>>.) Product vendors that wish to support Java IDL on a Java SE version that does not provide the Java IDL APIs must otherwise provide those APIs to application components.]
 * JDBC
 * RMI-JRMP
-* RMI-IIOP footnote:[Removed from Java SE 11. Support for RMI-IIOP is optional (see <<a3538, RMI-IIOP (Optional)>>.) Product vendors that wish to support RMI-IIOP on a Java SE version that does not provide the RMI-IIOP APIs must otherwise provide those APIs to application components. Product vendors that support the optional Enterprise Beans 2.x API group must ensure that the javax.rmi.PortableRemoteObject class is available to application components.]
+* RMI-IIOP footnote:[Removed from Java SE 11. Support for RMI-IIOP is optional (see <<a3538, RMI-IIOP (Optional)>>.) Product vendors that wish to support RMI-IIOP on a Java SE version that does not provide the RMI-IIOP APIs must otherwise provide those APIs to application components.]
+* javax.rmi.PortableRemoteObject footnote:[Removed from Java SE 11. Product vendors that support the optional Enterprise Beans 2.x API group must ensure that the javax.rmi.PortableRemoteObject class is available to application components.]
 * JNDI
 * JAXP
 * StAX

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -36,13 +36,18 @@ apply.
 The containers provide all application
 components with at least the Java Platform, Standard Edition, v8 (Java
 SE) APIs. Containers may provide newer versions of the Java SE platform,
-provided they meet all the Jakarta EE platform requirements. If the container
-provides a version of the Java SE platform newer than Java SE 8 and that
-version no longer includes one or more APIs that were available in Java SE 8,
-the container is not required to provide those APIs, unless they are
-one of the enterprise technologies listed in this specification.
+provided they meet all the Jakarta EE platform requirements as outlined below.
 
-The Java SE platform includes the following enterprise technologies:
+===== Java SE Enterprise Technologies
+
+The Java SE 8 platform includes a number of enterprise technologies. Except
+for technologies noted in this specification as being optional, containers
+must provide all application components with the APIs associated with these
+technologies. If a newer version of the Java SE platform provided by
+a container has removed some of these technologies, the container must
+provide these technologies in some other manner.
+
+The Java SE 8 platform includes the following enterprise technologies:
 
 * Java IDL footnote:[Removed from Java SE 11. Support for Java IDL is optional (see <<a3539, Java IDL (Optional)>>.) Product vendors that wish to support Java IDL on a Java SE version that does not provide the Java IDL APIs must otherwise provide those APIs to application components.]
 * JDBC
@@ -54,16 +59,15 @@ The Java SE platform includes the following enterprise technologies:
 * StAX
 * JAAS
 * JMX
-* JAX-WS footnote:javaremoval[Removed from Java SE 11. See <<a2161, Required Jakarta Technologies>>.]
-* JAXB footnote:javaremoval[]
-* JAF footnote:javaremoval[]
-* SAAJ footnote:javaremoval[]
-* Common Annotations footnote:javaremoval[]
+* JAX-WS footnote:javaremovalopt[Removed from Java SE 11. Since Jakarta EE 9 this optional technology is provided under a Jakarta EE specification. If the technology is provided, the container must provide the Jakarta EE version of the technology. See <<a2161, Required Jakarta Technologies>>.]
+* JAXB footnote:javaremovalopt[]
+* JAF footnote:javaremovalreq[Removed from Java SE 11. Since Jakarta EE 9 this technology is provided under a Jakarta EE specification. The container must provide the Jakarta EE version of the technology. See <<a2161, Required Jakarta Technologies>>.]
+* SAAJ footnote:javaremovalopt[]
+* Common Annotations footnote:javaremovalreq[]
 
-Some of the enterprise technologies that are
-included in Java SE 8 are also available independently of the Java SE
-platform, and this specification requires newer versions of some of
-these technologies, as described in the following section.
+Note that a number of the enterprise technologies provided
+by Java SE 8 are now provided by Jakarta EE specifications and are
+included in the list of <<a2161, Required Jakarta Technologies>>.
 
 The specifications for the Java SE APIs are
 available at _http://docs.oracle.com/javase/8/docs/_ .

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -30,13 +30,19 @@ might nonetheless include support for the technology. In such a case,
 the requirements for that technology described in this chapter would
 apply.
 
+[[a3537]]
 ==== Java Compatible APIs
 
 The containers provide all application
 components with at least the Java Platform, Standard Edition, v8 (Java
 SE) APIs. Containers may provide newer versions of the Java SE platform,
-provided they meet all the Jakarta EE platform requirements. The Java SE
-platform includes the following enterprise technologies:
+provided they meet all the Jakarta EE platform requirements. If the container
+provides a version of the Java SE platform newer than Java SE 8 and that
+version no longer includes one or more APIs that were available in Java SE 8,
+the container is not required to provide those APIs, unless they are
+one of the enterprise technologies listed in this specification.
+
+The Java SE platform includes the following enterprise technologies:
 
 * Java IDL footnote:javaremoval[Removed from Java SE 11. See <<a2161, Required Jakarta Technologies>>.]
 * JDBC
@@ -52,15 +58,6 @@ platform includes the following enterprise technologies:
 * JAF footnote:javaremoval[]
 * SAAJ footnote:javaremoval[]
 * Common Annotations footnote:javaremoval[]
-
-In particular, the applet execution
-environment must be Java SE 8 compatible. Since typical browsers don’t
-yet provide such support, Jakarta EE products may make use of the Java
-Plugin to provide the required applet execution environment. Use of the
-Java Plugin is not required, but is one method of meeting the
-requirement to provide a Java SE 8 compatible applet execution
-environment. This specification adds no requirements to the applet
-container beyond those specified by Java SE.
 
 Some of the enterprise technologies that are
 included in Java SE 8 are also available independently of the Java SE
@@ -329,6 +326,11 @@ technology.footnote:[Note that a component specification is permitted to specify
 an exception to this in order to accommodate interface type dependencies—for example,
 the Jakarta™ Enterprise Beans SessionContext dependency on the
 _jakarta.xml.rpc.handler.MessageContext_ type.]
+
+If a container supports a newer version of the Java SE platform than
+Java SE 8, all classes and interfaces provided by the container to
+satisfy the platform requirements listed above must be compiled
+with the Java SE 8 source and class level.
 
 
 [[a2331]]

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -283,12 +283,14 @@ transaction boundaries.
 * An interface between the transaction manager
 and a resource manager used at the Jakarta EE SPI level.
 
+[[a3538]]
 ==== RMI-IIOP (Optional)
 
 Support for CORBA, including use of IIOP and
 Java IDL, is Optional as of Jakarta EE 9. See
 <<a2331, Optional Jakarta Technologies>>.
 
+[[a3539]]
 ==== Java IDL (Optional)
 
 Support for CORBA, including use of IIOP and

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -199,11 +199,10 @@ bean container.
 ==== Container Requirements
 
 This specification requires that containers
-provide a Java Compatible™ runtime environment, as defined by the Java
-Platform, Standard Edition, v8 specification (Java SE). The applet
-container may use the Java Plugin product to provide this environment,
-or it may provide it natively. The use of applet containers providing
-JDK™ 1.1 APIs is outside the scope of this specification.
+support execution in a Java™ runtime environment, as defined by the Java
+Platform, Standard Edition, v11 specification (Java SE 11). Containers may additionally choose
+to support execution in another Java™ runtime environment, as defined by a Java
+Platform, Standard Edition, v8 or later specification.
 
 The container tools must understand the file
 formats for the packaging of application components for deployment.

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -200,9 +200,7 @@ bean container.
 
 This specification requires that containers
 support execution in a Java™ runtime environment, as defined by the Java
-Platform, Standard Edition, v11 specification (Java SE 11). Containers may additionally choose
-to support execution in another Java™ runtime environment, as defined by a Java
-Platform, Standard Edition, v8 or later specification.
+Platform, Standard Edition specification, v8 or later (Java SE 8 or later).
 
 The container tools must understand the file
 formats for the packaging of application components for deployment.


### PR DESCRIPTION
…ther than SE 8.

1) Update the Platform Overview to state that containers must support SE 11, but may also support SE 8 or later.

2) Update the Java Compatible APIs section to note that if a newer SE than SE 8 is provided, APIs removed from SE since 8 are not required unless noted in the EE specification.

3) Remove the discussion of applet support and the Java Plugin from the Java Compatible APIs section.

4) Update various classloading requirements sections in the Application Assembly Deployment section to no longer explicitly reference SE 8 but rather to more general reference Java SE with a link back to the Java Compatible APIs section

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

Resolves #287 