### PR TITLE
Update 9.1 schedule for 2Q

### DIFF
--- a/jakartaee9/JakartaEE9.1.md
+++ b/jakartaee9/JakartaEE9.1.md
@@ -20,11 +20,18 @@ The key goal of the [Jakarta EE 9.1 Release Plan](JakartaEE9.1ReleasePlan) is to
 
 No other individual component (feature) release plans are expected.
 
-## Jakarta EE 9.1 schedule (TBD)
+## Jakarta EE 9.1 schedule (work in progress)
 
 Overall schedule dates are ***tentative*** and ***subject to change***.  
     
-- Final Jakarta EE 9.1 release (Java SE 11) - **1Q2021** completion (proposed)
+- Final Jakarta EE 9.1 release (Java SE 11) - **2Q2021** completion (proposed)
+ - [Jakarta EE 9.1 RC1 Platform API]()
+ - [Jakarta EE 9.1 RC1 Web Profile API]()
+ - [Glassfish 6.2 M1](tbd)
+
+**Update 03/10/2021:**  The original goal for delivering Jakarta EE 9.1 was 1Q2021.
+This is no longer achievable.
+The new goal is 2Q2021. 
     
 ### Jakarta EE 9.1 Project board
 

--- a/jakartaee9/JakartaEE9.1.md
+++ b/jakartaee9/JakartaEE9.1.md
@@ -25,9 +25,9 @@ No other individual component (feature) release plans are expected.
 Overall schedule dates are ***tentative*** and ***subject to change***.  
     
 - Final Jakarta EE 9.1 release (Java SE 11) - **2Q2021** completion (proposed)
- - [Jakarta EE 9.1 RC1 Platform API]()
- - [Jakarta EE 9.1 RC1 Web Profile API]()
- - [Glassfish 6.2 M1](tbd)
+ - [Jakarta EE 9.1 RC1 Platform API](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-api/9.1.0-RC1/jar)
+ - [Jakarta EE 9.1 RC1 Web Profile API](https://search.maven.org/artifact/jakarta.platform/jakarta.jakartaee-web-api/9.1.0-RC1/jar)
+ - [Eclipse Glassfish 6.1 M1](tbd)
 
 **Update 03/10/2021:**  The original goal for delivering Jakarta EE 9.1 was 1Q2021.
 This is no longer achievable.

--- a/jakartaee9/JakartaEE9.1ReleasePlanFAQ.md
+++ b/jakartaee9/JakartaEE9.1ReleasePlanFAQ.md
@@ -10,20 +10,20 @@ This FAQ should be used to complement the [Jakarta EE 9.1 Release Plan](https://
 - [Can the Javadoc be updated?](#can-the-javadoc-be-updated)
 
 **CORBA**
-- [Why not just remove the CORBA requirement?](#why-not-just-remove-the-CORBA-requirement)
+- [Why not just remove the CORBA requirement?](#why-not-just-remove-the-corba-requirement)
 
 
 ### Can the Specifications be updated?
 
 Yes, as long as it does not introduce any functional changes.
-Any updates to a Component's Specification will need to conform to the rules of a Service Release (x.y.z).
+Any updates to a Component's Specification will need to conform to the [Service Release (x.y.z) process](https://jakarta.ee/committees/specification/operations/#creating_a_final_service_release_specification) in support of the [JESP](https://jakarta.ee/about/jesp/).
 
 **Note:** The Jakarta EE 9.1 Platform Specification will be updated in support of the Java SE 11 requirement.
 
 ### Can the Javadoc be updated?
 
 Yes, as long as it does not introduce any functional changes.
-Any updates to a Component's Javadoc will need to conform to the rules of a Service Release (x.y.z).
+Any updates to a Component's Javadoc will need to conform to the [Service Release (x.y.z) process](https://jakarta.ee/committees/specification/operations/#creating_a_final_service_release_specification) in support of the [JESP](https://jakarta.ee/about/jesp/).
 
 ### Why not just remove the CORBA requirement?
 


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Updated 9.1 schedule with 2Q information.  Also, updated the FAQ with references to Ops Guide definition of Service Release process.