### PR TITLE
Hilite that CORBA and Orb References are Optional

### DIFF
--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -2501,6 +2501,9 @@ required by this specification.
 [[a1385]]
 === ORB References
 
+NOTE:  The requirements in this section only apply to
+Jakarta EE products that include support for interoperability using CORBA.
+
 Some Jakarta EE applications will need to make use
 of the CORBA ORB to perform certain operations. Such applications can
 find an appropriate object implementing the _ORB_ interface by looking
@@ -2552,9 +2555,6 @@ descriptor entry may also be a shared instance. However, the application
 may set the _shareable_ element of the _Resource_ annotation to _false_
 , or may set the _res-sharing-scope_ element in the deployment
 descriptor to _Unshareable_ , to request a non-shared _ORB_ instance.
-
-The requirements in this section only apply to
-Jakarta EE products that include support for interoperability using CORBA.
 
 ==== Application Component Provider’s Responsibilities
 

--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -2499,10 +2499,9 @@ providing an appropriate _TransactionSynchronizationRegistry_ object as
 required by this specification.
 
 [[a1385]]
-=== ORB References
+=== ORB References (optional)
 
-NOTE:  The requirements in this section only apply to
-Jakarta EE products that include support for interoperability using CORBA.
+NOTE: Support for CORBA as an application service is optional.
 
 Some Jakarta EE applications will need to make use
 of the CORBA ORB to perform certain operations. Such applications can


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

I just re-reviewed the requirements as outlined in Issue #300, and this is the only section that I think needs any modification.  I moved this "CORBA is optional" message from the end of this subsection to the top and highlighted it.  I think the rest of the Platform spec is good with the CORBA as an optional technology message.