### PR TITLE
Managed Beans version should be 2.1-SNAPSHOT

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -41,7 +41,7 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <managedbean.version>2.0</managedbean.version>  <!-- override <version> for Managed Beans spec-->
+        <managedbean.version>2.1-SNAPSHOT</managedbean.version>  <!-- override <version> for Managed Beans spec-->
     </properties>
 
     <scm>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

Managed Beans is not being updated for Jakarta EE 9.1, so the version should be set to 2.1-SNAPSHOT for normal development builds.