### PR TITLE
Add Connectors 2.1 to to the list

### DIFF
--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -188,6 +188,7 @@ The following technologies are required:
 * Jakarta Batch 2.1*
 * Jakarta Bean Validation 3.0
 * Jakarta Concurrency 3.0*
+* Jakarta Connectors 2.1*
 * Jakarta Contexts and Dependency Injection 4.0*
 * Jakarta Debugging Support for Other Languages 2.0
 * Jakarta Dependency Injection  2.0


### PR DESCRIPTION
Noticed Connectors 2.1 is missing from the list of required specifications.